### PR TITLE
Regression front-end study + head hardening

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -11,10 +11,13 @@ log-likelihood protocols as documented in each file's docstring.
 
 | script | study |
 |---|---|
-| `ucr_run.py` | UCR Anomaly Archive: wald scorers vs ablations/trivial |
+| `ucr_run.py` | UCR Anomaly Archive: Wald scorers vs ablations/trivial |
 | `frontend_run.py` | detector front-end lift: DSPOT/RRCF on raw vs parade z |
 | `frontend_loglik.py` | forecaster front-end lift: ETS/ARIMA/GARCH/Prophet, exact change of variables |
 | `fred_anomaly.py` | FRED injection benchmark (spike/burst/shift on real backgrounds) |
+| `regression_frontend.py` | online regression front-end lift: one RLS learner, coordinates varied (raw/affine/robust/Laplace-z), contaminated simulation |
+| `river_frontend.py` | same question, river's learners: Laplace front-end vs river's StandardScaler/TargetStandardScaler pipeline (needs `pip install river`) |
+| `river_data_frontend.py` | the ticket gate: same comparison on river's own regression datasets, as-is and feature-spiked, with a body-alone attribution column |
 
 Third-party baselines need the extra: `pip install "timemachines[benchmarks]"`.
 
@@ -61,13 +64,16 @@ export TIMEMACHINES_FRED_DATA=/path/to/fred/data
 | `frontend_loglik.py --limit 30` | forecaster lift | ~1 CPU-h (ARIMA/Prophet refits) |
 | `fred_anomaly.py --limit 100` | FRED injection | ~4 CPU-h |
 | `rosenblatt_sandwich.py` | 12 price series | ~10 CPU-min |
+| `regression_frontend.py --seeds 30` | 240 simulated runs | ~7 CPU-min |
+| `river_frontend.py --seeds 30` | 240 simulated runs | ~20 CPU-min |
+| `river_data_frontend.py` | 4 river datasets, 44 runs | ~15 CPU-min |
 
 ### Bigger-machine targets, in value order
 
 1. `frontend_run.py --limit 250` — the detector-lift headline at full-archive scale.
 2. `calibration_panel.py` with a 1e-5 column (edit `ALPHAS`) and `CAP=50000`
    — deeper tail, more clean points per series.
-3. `ucr_run.py --base zbank` full 250 (feature bank, ~6x laplace cost).
+3. `ucr_run.py --base zbank` full 250 (feature bank, ~6x Laplace cost).
 4. `frontend_loglik.py --limit 200` — forecaster lift on the whole universe.
 5. FRED-injection v2 (rank-percentile scoring — see RESULTS.md section 5)
    before spending compute on the argmax version.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,6 +18,8 @@ log-likelihood protocols as documented in each file's docstring.
 | `regression_frontend.py` | online regression front-end lift: one RLS learner, coordinates varied (raw/affine/robust/Laplace-z), contaminated simulation |
 | `river_frontend.py` | same question, river's learners: Laplace front-end vs river's StandardScaler/TargetStandardScaler pipeline (needs `pip install river`) |
 | `river_data_frontend.py` | the ticket gate: same comparison on river's own regression datasets, as-is and feature-spiked, with a body-alone attribution column |
+| `ablation_frontend.py` | mu-vs-z ablation on the simulation: which of the two scalars carries the value |
+| `ablation_river.py` | same ablation on river's datasets, dogfooding the published ice-skaters package (needs `pip install ice-skaters`) |
 
 Third-party baselines need the extra: `pip install "timemachines[benchmarks]"`.
 
@@ -67,6 +69,8 @@ export TIMEMACHINES_FRED_DATA=/path/to/fred/data
 | `regression_frontend.py --seeds 30` | 240 simulated runs | ~7 CPU-min |
 | `river_frontend.py --seeds 30` | 240 simulated runs | ~20 CPU-min |
 | `river_data_frontend.py` | 4 river datasets, 44 runs | ~15 CPU-min |
+| `ablation_frontend.py --seeds 30` | 240 simulated runs | ~5 CPU-min |
+| `ablation_river.py` | 4 river datasets, 44 runs | ~45 CPU-min (12 models/row) |
 
 ### Bigger-machine targets, in value order
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -17,7 +17,7 @@ directory. Updated 2026-07-07.
 Same detector, same series; only the input changes (raw y vs parade z from
 `laplace(3)`). `frontend_run.py`, n = 60 shortest UCR series.
 
-| detector | raw | laplace-fronted | lift |
+| detector | raw | Laplace-fronted | lift |
 |---|---|---|---|
 | DSPOT (EVT thresholding, KDD 2017) | 6/60 = 0.100 | **31/60 = 0.517** | **5.2x** |
 | RRCF (random cut forest, ICML 2016) | 15/60 = 0.250 | **27/60 = 0.450** | **1.8x** |
@@ -41,12 +41,12 @@ series, rolling refit every 200 on trailing 1000.
 | GARCH(1,1) (arch) | 1.732 | 3.703 | **+1.97** | +0.77 | **30/30** |
 | Prophet (real calendar dates) | 1.636 | 3.702 | **+2.07** | **+0.85** | **30/30** |
 | EWMA-Gauss (control head) | 2.243 | 3.795 | +1.55 | +0.51 | 29/30 |
-| *laplace alone (reference)* | | *3.674* | | | |
+| *Laplace alone (reference)* | | *3.674* | | | |
 
-Bijection prediction verified: fronted opponents converge to laplace + eps
-(AutoARIMA adds +0.045 nats over laplace alone — laplace had already
+Bijection prediction verified: fronted opponents converge to Laplace + eps
+(AutoARIMA adds +0.045 nats over Laplace alone — Laplace had already
 extracted ~98% of the structure ARIMA can model). The control head on z
-reproduces laplace's own score, confirming the Jacobian accounting.
+reproduces Laplace's own score, confirming the Jacobian accounting.
 
 The hardest case — GARCH-t on its home turf (12 price/return series:
 equities, FX majors, oil, gas, VIX; Student-t density scored exactly):
@@ -55,27 +55,27 @@ equities, FX majors, oil, gas, VIX; Student-t density scored exactly):
 |---|---|---|---|---|
 | GARCH-t | 2.630 | **2.708** | **+0.078** | **12/12** |
 | GARCH(1,1) Gaussian | 2.496 | 2.693 | +0.20 | 12/12 |
-| *laplace alone* | | *2.700* | | |
+| *Laplace alone* | | *2.700* | | |
 
 Even the model that wins on price series gains in the transformed
-coordinates, and the composite (laplace front-end + GARCH-t on z) is the
+coordinates, and the composite (Laplace front-end + GARCH-t on z) is the
 best cell measured — the composition `laplace(leaf=garch_leaf)` already
-ships in skaters. Caveat: raw GARCH-t trailing laplace alone here differs
+ships in skaters. Caveat: raw GARCH-t trailing Laplace alone here differs
 from the skaters paper's price-table verdict; this protocol (rolling
 200-refit, 1000-window, 3000-point cap) is not that one.
 
 Prophet is the sharpest row: its calendar machinery (weekday/yearly from
-real dates — structure laplace's integer-lag seasonal block cannot
+real dates — structure Laplace's integer-lag seasonal block cannot
 represent) earns the largest median lift when fronted, yet adds only
-+0.03 nats over laplace alone: even the calendar model finds almost
++0.03 nats over Laplace alone: even the calendar model finds almost
 nothing left in the residuals. FINAL: five opponents, 149/150 wins.
 
 ### The sandwich as an object (`rosenblatt_sandwich.py`)
 
-Change of variables scores laplace -> inner -> laplace^-1 exactly for
+Change of variables scores Laplace -> inner -> Laplace^-1 exactly for
 log-lik (the tables above). Built as an actual predictive object (quantile-
 grid pushforward, k=1), it currently pays ~0.06 nats of representation tax
-— more than the inner's true add over laplace on prices (~+0.01), so the
+— more than the inner's true add over Laplace on prices (~+0.01), so the
 object loses 0/12 there while `garch_leaf` directly on y wins 9/12 (the
 no-free-lunch caveat at object level). The object route matters for
 delivering CRPS/intervals of fronted models; route and open items in
@@ -88,7 +88,7 @@ The own head's UCR standing, full 250,
 default config is: best scorer (|z1|) 0.276 vs trivial 0.216. The diagnostic
 split: **0.500 on the 84 series <= 20k points; 0.169 on the 166 longer ones**
 — two-thirds of the archive is 20k-900k-point periodic physiology whose
-waveform periods (~50-400 samples) the laplace body cannot represent (its
+waveform periods (~50-400 samples) the Laplace body cannot represent (its
 seasonal grid is calendar {7,12,24}), so every cycle reads as fresh surprise.
 That is a *body* weakness observed through the head — filed upstream as
 skaters#91 — and matrix-profile methods own that terrain by construction.
@@ -110,18 +110,18 @@ skaters' state-purity fix enabling checkpoint/restore (0.12.1).
 
 `calibration_panel.py`: 144 UCR anomaly-free prefixes (clean by
 construction; every flag a false alarm), strictly prequential — thresholds
-and nulls never see the data they are scored on. wald flags at p < alpha;
+and nulls never see the data they are scored on. Wald flags at p < alpha;
 DSPOT at its own EVT risk (alpha/2 per tail); RRCF has no nominal
 semantics, so it is deployed the only way an uncalibrated score can be:
 threshold pre-committed on the first half, measured on the second.
 
 | empirical FPR / nominal (1.0 = calibrated) | 1e-2 | 1e-3 | 1e-4 |
 |---|---|---|---|
-| wald (Mahalanobis + deep-evidence channels) | 1.69 | **1.86** | **3.20 (median series 1.00)** |
+| Wald (Mahalanobis + deep-evidence channels) | 1.69 | **1.86** | **3.20 (median series 1.00)** |
 | DSPOT (KDD 2017) | **0.98** | 1.95 | 9.34 |
 | RRCF threshold transfer | 1.10 | 1.64 | 5.42 |
 
-At the depth where alarms operate, wald is the best-calibrated of the
+At the depth where alarms operate, Wald is the best-calibrated of the
 three and its median series is exact; the aggregate 3.2 is a tail of
 waveform-burst prefixes. Getting here required two head upgrades this
 panel itself forced: the bulk Satterthwaite null alone ran 39x at 1e-4
@@ -142,7 +142,168 @@ confounded measure. v2: score the planted window's rank percentile in the
 full score ordering (robust to dominant natural events), and/or mask known
 crisis windows. Keep argmax row for reference.
 
-## 6. Still to come
+## 6. Regression front-end — contaminated simulation (240 runs)
+
+`regression_frontend.py`: the front-end thesis pointed at online regression.
+One fixed dumb learner (RLS, forgetting 0.999) predicts y one step ahead on
+a linear Gaussian pair (x AR(0.8) driving y, beta=1); only the coordinate
+system varies. The headline condition is **zin**: each stream is replaced
+by two scalars from its own `laplace(1)` body — the one-step predictive
+mean and the parade surprise z — and the target stays raw. 8 scenarios
+x 30 seeds; excess MSE vs the clean conditional mean (oracle = 0), median
+over seeds. Same 33-node pinball CRPS estimator for every condition.
+Output-fixing conditions ran too; they are a footnote (end of section).
+
+| scenario | Laplace | raw | zscore | robust | huber | zin |
+|---|---|---|---|---|---|---|
+| clean | 1.14 | **0.001** | 0.036 | 0.108 | 0.001 | 0.057 |
+| spikes_x | 1.15 | 1.08 | 0.98 | 0.91 | 1.38 | **0.72** |
+| spikes_y | 15.6 | 3.78 | 5.66 | 4.42 | 3.75 | **1.84** |
+| spikes_both | 16.0 | 9.05 | 9.78 | 7.66 | 9.65 | **6.33** |
+| heavy (t2) | 9.54 | 0.008 | 2.05 | 2.17 | **0.006** | 0.95 |
+| drift | 3.59 | **0.003** | 0.059 | 0.232 | 0.003 | 0.059 |
+| distort | 1.17 | 1.05 | 0.71 | 0.53 | 1.48 | **0.51** |
+| shift | 1.22 | **0.001** | 0.105 | 0.159 | 0.001 | 0.089 |
+
+(robust = median/MAD + winsorize at 4; huber = raw coordinates, clipped
+RLS update; zscore = EWMA-standardized, the RevIN-style affine case.)
+
+Reading, in order of importance:
+
+- **Fixing the inputs is nearly free insurance.** zin beats raw 30/30 on
+  every contaminated scenario — x-spikes, y-spikes, both, distortion — and
+  beats the robust affine baseline on all of them too (it halves raw's MSE
+  under y-spikes). Its clean toll is 0.057 excess MSE (CRPS 0.32 vs 0.28).
+- **Heavy tails are not contamination.** With genuine t(2) driving noise
+  and a correctly specified linear model, the extreme points are the most
+  informative ones; raw and huber sit at the oracle and every coordinate
+  fix pays dearly for taming the signal. The practitioner's question
+  "are my tails noise or signal?" decides the coordinates.
+- **Monotone distortion is home turf** (the nonparanormal generative
+  model): zin 0.51 vs raw 1.05, 30/30 — here the coordinates *are* the
+  model.
+- **The loss is the wrong place to fix inputs**: huber tracks raw
+  everywhere except x-spikes, where clipping the residual cannot repair a
+  corrupted feature and it loses to raw (1.38 vs 1.08).
+- Caveat on the shift row: a level shift in x passes straight through a
+  correctly specified linear map, so raw recovers instantly; that row
+  tests specification, not adaptation — a target-intercept shift is the
+  v2 scenario.
+
+### The same question with river's learners (`river_frontend.py`)
+
+Third-party learners, third-party baseline: river 0.25's LinearRegression
+(SGD) and HoeffdingTreeRegressor under river's own recommended pipeline —
+`StandardScaler` on features, `TargetStandardScaler` on the target — vs
+the Laplace front-end composed WITH that same pipeline (features replaced
+by body means + surprises). Same generator, scenarios, seeds and metric as
+above. Median excess MSE, and lapin-vs-std wins out of 30 (sign test:
+30/30 is p = 1.9e-9, 26/30 is p = 5e-5):
+
+| scenario | lin std | lin lapin | wins | tree std | tree lapin | wins |
+|---|---|---|---|---|---|---|
+| clean | **0.010** | 0.080 | 0/30 | **0.011** | 0.086 | 0/30 |
+| spikes_x | 1.26 | **0.94** | **30/30** | 1.30 | **0.96** | **30/30** |
+| spikes_y | 5.04 | **3.12** | **30/30** | 4.48 | **3.45** | **27/30** |
+| spikes_both | 11.1 | **9.2** | **27/30** | 7.9 | 8.1 | 16/30 |
+| heavy (t2) | **0.21** | 1.43 | 7/30 | **0.21** | 1.29 | 4/30 |
+| distort | 1.10 | **0.81** | **26/30** | 1.11 | **0.88** | 19/30 |
+
+Reading: the section-6 pattern survives the transplant. Under measurement
+contamination and monotone distortion the front-end lifts river's
+canonical pipeline significantly on its two model-based learners; on
+clean/drift/shift data it pays the same small toll, and the informative-
+tails caveat (heavy) transfers unchanged. Bare unscaled SGD diverges
+(excess MSE up to 1e25), confirming the std pipeline as the only fair
+baseline. Boundaries disclosed: KNNRegressor is the counterexample —
+neighbour averaging is already spike-robust and extra surprise dimensions
+degrade its distance metric, so the front-end hurts it nearly everywhere.
+Before any upstream ticket: repeat on river's own real datasets with
+progressive validation.
+
+### River's own data (`river_data_frontend.py`) — the ticket gate
+
+Four river regression datasets, progressive validation, MAE, numeric
+features only (dropped symmetrically), Bikes capped at 20k of 182k rows.
+`body` = the target's Laplace predictive mean alone, no regression, no
+features — the attribution control. Untouched data (asis), tree learner:
+
+| dataset | std | lapin | body |
+|---|---|---|---|
+| TrumpApproval | 0.334 | 0.381 | **0.150** |
+| ChickWeights | **23.8** | 24.7 | 25.5 |
+| AirlinePassengers | 41.9 | **26.6** | 29.4 |
+| Bikes (20k) | 5.07 | 5.29 | **4.94** |
+
+With 2% feature spikes (10 seeds), lapin beats std 10/10 on TrumpApproval,
+AirlinePassengers and Bikes for the tree learner (9/10, 10/10, 0/10 for
+linear), and 1-3/10 on ChickWeights.
+
+Reading: on history-dominated streams (three of the four datasets) the
+univariate body ALONE already beats river's full feature pipeline — on
+river's own flagship example by 2.2x — the section-2 finding transplanted
+to regression: the features add almost nothing the calibrated forecaster
+had not already extracted.
+Where the features genuinely carry entity identity that an interleaved
+single-stream body cannot represent (ChickWeights: 50 chick growth curves,
+per-entity bodies are the obvious v2), the pipeline keeps its edge and the
+front-end honestly loses. The insurance claim transfers to real
+backgrounds: under feature contamination the front-end wins 10/10 wherever
+it was competitive as-is. Disclosed instability: river's default SGD
+LinearRegression degrades on Bikes in every coordinate system (14.4 asis
+vs the tree's 5.07) and diverges outright on the lapin features (MAE
+2.5e10); the tree learner is the fair carrier of the comparison there.
+
+The river ticket case, stated plainly: (1) a calibrated forecaster's
+state — predictive mean plus standardized surprise — is a strong feature
+set and baseline that river has no native transformer for; (2) it makes
+model-based pipelines significantly more robust to feature contamination.
+Boundaries to state in the ticket: distance-based learners (KNN), entity-
+interleaved streams without per-entity bodies, and genuinely informative
+heavy tails.
+
+The integration ships as its own micro-package, deep-river style, so
+river core is never asked to carry a dependency and timemachines stays
+one layer up: [ice-skaters](https://github.com/microprediction/ice-skaters)
+(skaters on a river) provides `LaplaceFeatures` (a river Transformer;
+each numeric stream becomes the (mean, z) pair, non-numerics pass
+through, NaN is forecast-imputed) and `LaplaceTarget` (a regressor
+wrapper adding the target's own pair, in the style of
+TargetStandardScaler). Both pickle and deep-copy; predict and learn
+paths see identical features despite Pipeline's learn-then-transform
+ordering. Runnable demo in that repo, `examples/trump_approval.py`
+(TrumpApproval: baseline 0.328 clean / 0.597 under 2% corrupted
+pollster readings; fronted 0.382 / 0.407). The ticket should say plainly
+that we are unsure a skaters dependency is desirable — the package is
+young — and note the alternative: skaters is stdlib-only pure Python
+(no numpy, runs in Pyodide), so a frozen version could be vendored into
+river in river-idiomatic form if the maintainers ever wanted it native;
+the generic shape would be a ForecasterFeatures transformer wrapping any
+of river's own time_series models, with Laplace as one plug.
+
+### Footnote: the output sandwich (dropped from the recommendation)
+
+All three harnesses also ran output-fixing conditions: zout (raw
+features, the target's parade z as the learn target, mapped back through
+the body's predictive CDF) and the full sandwich (z on both sides,
+33-node quadrature in the RLS harness, plug-in for river's point
+learners). Verdict: everywhere the sandwich won, input fixing was at its
+heels (distort 0.50 vs zin's 0.51; spikes_x 0.71 vs 0.72), and on
+river's real data it was body plus epsilon (TrumpApproval 0.158 vs the
+body's 0.150; Bikes 4.90 vs 4.94). Its one distinctive behaviour is the
+failure mode: under target spikes the default-memory body chases the
+contamination and the map-back amplifies it — zout 226 vs raw's 3.8,
+sandwich 38.5, clean toll 0.170. Input fixing has bounded influence by
+construction; output fixing is only as sound as the body's own
+robustness (a slow-memory body, `scale_alpha=0.01`, is the predicted but
+untested fix). The construction stays in the harnesses and in the theory
+— the log-loss isometry and the KL decomposition live on the output
+bijection, and it is the only route from point learners to
+distributional outputs (CRPS, intervals) — but it exits the practical
+recommendation: fix the inputs, keep the target raw. Self-hosting route:
+skaters#92.
+
+## 7. Still to come
 
 - slow-alpha full-250 (running); zbank-60 and default-250 (running,
   detached).
@@ -153,6 +314,10 @@ crisis windows. Keep argmax row for reference.
   theorem for our head); unclamped -logpdf surprise channel (the z-clamp
   saturates at |z|=7.03, erasing 20-sigma vs 100-sigma distinctions).
 - TSB-AD-U leaderboard run (VUS-PR; top is 0.42, simple methods lead).
+- Regression front-end v2: slow-memory body for the zout/spikes_y cell;
+  target-intercept shift scenario; then the real-data prong (FRED
+  cross-series regression) and the academic prong (RevIN/DAIN/Dish-TS on
+  ETT with the same dumb learner).
 
 ## Reproduce
 
@@ -161,6 +326,9 @@ python benchmarks/anomaly/ucr_run.py --limit 60 --workers 8 [--scale-alpha 0.01 
 python benchmarks/anomaly/frontend_run.py --limit 60 --workers 4
 python benchmarks/anomaly/frontend_loglik.py --limit 30 --workers 3
 python benchmarks/anomaly/fred_anomaly.py --limit 100 --workers 4
+python benchmarks/regression_frontend.py --seeds 30 --workers 6
+python benchmarks/river_frontend.py --seeds 30 --workers 6   # pip install river
+python benchmarks/river_data_frontend.py --workers 6
 ```
 UCR data: see RESEARCH.md (download + extract into `data/UCR_Anomaly_FullData`).
 FRED data: cached under `benchmarks/data/` (see `benchmarks/fred.py`).

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -281,6 +281,53 @@ river in river-idiomatic form if the maintainers ever wanted it native;
 the generic shape would be a ForecasterFeatures transformer wrapping any
 of river's own time_series models, with Laplace as one plug.
 
+### The ablation: which scalar carries it, and what it costs
+
+`ablation_frontend.py` decomposes the pair on the section-6 simulation
+(same generator, seeds, RLS learner; excess MSE, medians):
+
+| scenario | raw | mu only | z only | the pair | pair, raw y lag |
+|---|---|---|---|---|---|
+| clean | **0.001** | 0.177 | 16.9 | 0.057 | 0.016 |
+| spikes_y | 3.78 | 3.21 | 17.6 | **1.84** | 2.38 |
+| heavy (t2) | 0.008 | 1.36 | 146 | 0.95 | 0.18 |
+| distort | 1.05 | 1.06 | 18.0 | **0.51** | 0.67 |
+
+z alone is useless: surprises carry no level, and a level cannot be
+regressed from pure news. mu alone pays a large clean toll and misses
+distortion. The pair is genuinely a unit — the learner recombines level
+and news into a conditional mean neither scalar supports alone. The
+target's own pair is insurance for the target specifically: swapping it
+for the raw y lag is better on clean/heavy/drift/shift and worse under
+target spikes and distortion.
+
+`ablation_river.py` repeats on river's datasets, dogfooding the published
+ice-skaters package, and adds the condition the earlier study missed:
+`lt` = LaplaceTarget alone, raw features untouched. MAE, tree learner,
+untouched data:
+
+| dataset | std | lt | full recipe |
+|---|---|---|---|
+| TrumpApproval | 0.334 | **0.301** | 0.387 |
+| ChickWeights | **23.8** | 24.1 | 24.5 |
+| AirlinePassengers | 41.9 | **26.6** | 29.5 |
+| Bikes (20k) | 5.07 | **5.01** | 5.51 |
+
+Under 2% feature spikes lt beats std 10/10 on TrumpApproval,
+AirlinePassengers and Bikes (tree; 6/10 on ChickWeights), despite its
+features being the raw, spiked ones — the target pair anchors the
+prediction and reduces reliance on corrupted features. **Revised
+recommendation, in order:** add the target pair always (one wrapper,
+helps clean and contaminated, ties the pipeline even on the
+counterexample dataset); replace features with their (mu, z) pairs only
+when you distrust the features; never use z alone.
+
+Cost, measured (`ice-skaters`, 3 numeric streams): LaplaceFeatures ~390
+microseconds per stream per sample vs ~0.4 for StandardScaler, a ~900x
+premium, i.e. ~2,500 samples/s per stream single-threaded. Right for
+polls, sensors and market bars; wrong inside a hot path at hundreds of
+thousands of ticks per second.
+
 ### Footnote: the output sandwich (dropped from the recommendation)
 
 All three harnesses also ran output-fixing conditions: zout (raw
@@ -301,7 +348,11 @@ untested fix). The construction stays in the harnesses and in the theory
 bijection, and it is the only route from point learners to
 distributional outputs (CRPS, intervals) — but it exits the practical
 recommendation: fix the inputs, keep the target raw. Self-hosting route:
-skaters#92.
+skaters#92. Theoretical resolution: the regret-transfer theorem
+(ice-skaters, `papers/regret-transfer.md`) proves the sandwich as a
+*density* can never lose more than O(d log T) nats to the body on any
+data sequence; the pathology above is a property of extracting the
+pushforward mean, not of the density.
 
 ## 7. Still to come
 
@@ -315,9 +366,14 @@ skaters#92.
   saturates at |z|=7.03, erasing 20-sigma vs 100-sigma distinctions).
 - TSB-AD-U leaderboard run (VUS-PR; top is 0.42, simple methods lead).
 - Regression front-end v2: slow-memory body for the zout/spikes_y cell;
-  target-intercept shift scenario; then the real-data prong (FRED
-  cross-series regression) and the academic prong (RevIN/DAIN/Dish-TS on
-  ETT with the same dumb learner).
+  target-intercept shift scenario; per-entity bodies (the ChickWeights
+  fix); k=3 multi-horizon surprise features for the drift/shift rows;
+  concept-drift classification (Elec2/Insects); then the FRED
+  cross-series prong and the academic prong (RevIN/DAIN/Dish-TS on ETT
+  with the same dumb learner). Done since the first pass: the mu-vs-z
+  ablation, the LaplaceTarget-only condition, per-tick cost, and the
+  regret-transfer theorem with its numerical check (both in
+  ice-skaters).
 
 ## Reproduce
 
@@ -329,6 +385,8 @@ python benchmarks/anomaly/fred_anomaly.py --limit 100 --workers 4
 python benchmarks/regression_frontend.py --seeds 30 --workers 6
 python benchmarks/river_frontend.py --seeds 30 --workers 6   # pip install river
 python benchmarks/river_data_frontend.py --workers 6
+python benchmarks/ablation_frontend.py --seeds 30 --workers 6
+python benchmarks/ablation_river.py --workers 6   # pip install ice-skaters
 ```
 UCR data: see RESEARCH.md (download + extract into `data/UCR_Anomaly_FullData`).
 FRED data: cached under `benchmarks/data/` (see `benchmarks/fred.py`).

--- a/benchmarks/ablation_frontend.py
+++ b/benchmarks/ablation_frontend.py
@@ -1,0 +1,147 @@
+"""Ablation: which of the two scalars carries the value, mu or z?
+
+The front-end replaces each stream with (predictive mean, surprise z).
+This harness decomposes the pair on the section-6 simulation: same
+generator, scenarios, seeds and RLS learner as regression_frontend.py,
+feature sets varied.
+
+    raw      [1, y_{t-1}, x_{t-1}]                 (control)
+    mu       [1, mu_y, mu_x]                        means only
+    z        [1, z_y, z_x]                          surprises only
+    both     [1, mu_y, z_y, mu_x, z_x]              the recipe (= zin)
+    both_nt  [1, y_{t-1}, mu_x, z_x]                inputs fixed, target
+                                                    pair replaced by the
+                                                    raw lag
+
+Metric: excess MSE vs the clean conditional mean, median over seeds.
+
+Usage:
+    python benchmarks/ablation_frontend.py --seeds 30 --workers 6
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import os
+import sys
+import time
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from regression_frontend import (  # noqa: E402
+    N, BURN, SCENARIOS, make_series, body_pass)
+
+CONDS = ("raw", "mu", "z", "both", "both_nt")
+
+
+class RLS:
+    def __init__(self, d, lam=0.999, p0=100.0):
+        self.d, self.lam = d, lam
+        self.w = [0.0] * d
+        self.P = [[(p0 if i == j else 0.0) for j in range(d)] for i in range(d)]
+
+    def predict(self, phi):
+        return sum(w * p for w, p in zip(self.w, phi))
+
+    def update(self, phi, target):
+        import math
+        err = target - self.predict(phi)
+        Pp = [sum(self.P[i][j] * phi[j] for j in range(self.d))
+              for i in range(self.d)]
+        denom = self.lam + sum(p * pp for p, pp in zip(phi, Pp))
+        g = [pp / denom for pp in Pp]
+        for i in range(self.d):
+            self.w[i] += g[i] * err
+        for i in range(self.d):
+            for j in range(self.d):
+                self.P[i][j] = (self.P[i][j] - g[i] * Pp[j]) / self.lam
+        tr = sum(self.P[i][i] for i in range(self.d))
+        if not math.isfinite(tr) or tr > 1e7:
+            self.__init__(self.d, self.lam)
+
+
+def run_one(job):
+    scenario, seed = job
+    obs_x, obs_y, m, y_clean, tau = make_series(scenario, seed)
+    t0 = time.time()
+    zy, ypred = body_pass(obs_y)
+    zx, xpred = body_pass(obs_x)
+
+    dims = {"raw": 3, "mu": 3, "z": 3, "both": 5, "both_nt": 4}
+    learners = {c: RLS(d) for c, d in dims.items()}
+    acc = {c: {"se": 0.0, "n": 0} for c in CONDS}
+
+    for t in range(2, N):
+        zy1 = zy[t - 1] if zy[t - 1] is not None else 0.0
+        zx1 = zx[t - 1] if zx[t - 1] is not None else 0.0
+        mu_y, mu_x = ypred[t].mean, xpred[t].mean
+        feats = {
+            "raw": [1.0, obs_y[t - 1], obs_x[t - 1]],
+            "mu": [1.0, mu_y, mu_x],
+            "z": [1.0, zy1, zx1],
+            "both": [1.0, mu_y, zy1, mu_x, zx1],
+            "both_nt": [1.0, obs_y[t - 1], mu_x, zx1],
+        }
+        for c in CONDS:
+            p = learners[c].predict(feats[c])
+            if t >= BURN:
+                acc[c]["se"] += (p - m[t]) ** 2
+                acc[c]["n"] += 1
+            learners[c].update(feats[c], obs_y[t])
+
+    res = {"scenario": scenario, "seed": seed}
+    for c in CONDS:
+        res[c] = acc[c]["se"] / acc[c]["n"]
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+def summarize(results):
+    print(f"\n=== mu-vs-z ablation, excess MSE vs conditional mean "
+          f"(median over seeds; n={len(results)} rows) ===")
+    print(f"{'scenario':12s} " + " ".join(f"{c:>9s}" for c in CONDS))
+    for sc in SCENARIOS:
+        rows = [r for r in results if r["scenario"] == sc]
+        if not rows:
+            continue
+        line = f"{sc:12s} "
+        for c in CONDS:
+            vals = sorted(r[c] for r in rows)
+            line += f"{vals[len(vals) // 2]:9.4f} "
+        print(line)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seeds", type=int, default=30)
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--out", type=str,
+                    default=os.path.join(_HERE, "ablation_frontend_results.jsonl"))
+    args = ap.parse_args()
+
+    jobs = [(sc, sd) for sc in SCENARIOS for sd in range(args.seeds)]
+    results = []
+    if os.path.exists(args.out):
+        with open(args.out) as fh:
+            results = [json.loads(line) for line in fh if line.strip()]
+        done = {(r["scenario"], r["seed"]) for r in results}
+        jobs = [j for j in jobs if j not in done]
+        print(f"resuming: {len(results)} done, {len(jobs)} to go", flush=True)
+
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(run_one, jobs)):
+            results.append(res)
+            with open(args.out, "a") as fh:
+                fh.write(json.dumps(res) + "\n")
+            print(f"[{i + 1}/{len(jobs)}] {res['scenario']:12s} "
+                  f"seed {res['seed']:<3d}", flush=True)
+
+    summarize(results)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ablation_river.py
+++ b/benchmarks/ablation_river.py
@@ -1,0 +1,143 @@
+"""Ablation on river's datasets, dogfooding the published ice-skaters.
+
+Decomposes the front-end's value on real data using the actual package a
+river user would install (`pip install ice-skaters`), same datasets,
+injection and protocol as river_data_frontend.py:
+
+    std      river's StandardScaler/TargetStandardScaler pipeline
+    lt       raw features + LaplaceTarget only (the target pair alone)
+    mu       LaplaceFeatures(emit="mu") + LaplaceTarget
+    z        LaplaceFeatures(emit="z") + LaplaceTarget
+    both     LaplaceFeatures(emit="both") + LaplaceTarget (the recipe)
+    both_nt  LaplaceFeatures(emit="both") without LaplaceTarget
+
+Usage:
+    python benchmarks/ablation_river.py --workers 6
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+import zlib
+import random as _random
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from river_data_frontend import _load, DATASETS, SPIKE_SEEDS  # noqa: E402
+
+LEARNERS = ("lin", "tree")
+CONDS = ("std", "lt", "mu", "z", "both", "both_nt")
+
+
+def _make(learner, cond):
+    from river import linear_model, preprocessing, tree
+    from ice_skaters import LaplaceFeatures, LaplaceTarget
+    base = {"lin": linear_model.LinearRegression,
+            "tree": tree.HoeffdingTreeRegressor}[learner]()
+    inner = preprocessing.StandardScaler() | base
+    if cond in ("mu", "z", "both", "both_nt"):
+        emit = cond if cond in ("mu", "z") else "both"
+        inner = LaplaceFeatures(emit=emit) | inner
+    model = preprocessing.TargetStandardScaler(regressor=inner)
+    if cond in ("lt", "mu", "z", "both"):
+        model = LaplaceTarget(regressor=model)
+    return model
+
+
+def run_one(job):
+    dsname, variant, seed = job
+    rows, numeric = _load(dsname)
+    n = len(rows)
+    burn = max(30, min(300, n // 10))
+    t0 = time.time()
+
+    xs = [{k: float(x[k]) for k in numeric} for x, _ in rows]
+    ys = [float(y) for _, y in rows]
+    if variant == "spikes":
+        rng = _random.Random(zlib.crc32(f"{dsname}:{seed}".encode()))
+        for k in numeric:
+            col = [r[k] for r in xs]
+            mu = sum(col) / n
+            sd = math.sqrt(sum((v - mu) ** 2 for v in col) / n) or 1e-8
+            for t in range(n):
+                if rng.random() < 0.02:
+                    xs[t][k] = col[t] + (6.0 + 4.0 * rng.random()) * sd \
+                        * rng.choice((-1, 1))
+
+    models = {(lr, c): _make(lr, c) for lr in LEARNERS for c in CONDS}
+    acc = {k: {"ae": 0.0, "n": 0} for k in models}
+    for t in range(n):
+        for key, model in models.items():
+            p = model.predict_one(xs[t])
+            p = p if p is not None else 0.0
+            if t >= burn:
+                acc[key]["ae"] += abs(p - ys[t])
+                acc[key]["n"] += 1
+            model.learn_one(xs[t], ys[t])
+
+    res = {"ds": dsname, "variant": variant, "seed": seed}
+    for (lr, c), a in acc.items():
+        res[f"{lr}_{c}"] = a["ae"] / a["n"]
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+def summarize(results):
+    print(f"\n=== river ablation, MAE (n={len(results)} rows) ===")
+    for variant in ("asis", "spikes"):
+        rows_v = [r for r in results if r["variant"] == variant]
+        if not rows_v:
+            continue
+        print(f"\n--- {variant} ---")
+        for lr in LEARNERS:
+            print(f"{lr}: {'dataset':18s} "
+                  + " ".join(f"{c:>8s}" for c in CONDS))
+            for ds in DATASETS:
+                rows = [r for r in rows_v if r["ds"] == ds]
+                if not rows:
+                    continue
+                line = f"    {ds:18s} "
+                for c in CONDS:
+                    vals = sorted(r[f"{lr}_{c}"] for r in rows)
+                    line += f"{vals[len(vals) // 2]:8.3f} "
+                print(line)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--out", type=str,
+                    default=os.path.join(_HERE, "ablation_river_results.jsonl"))
+    args = ap.parse_args()
+
+    jobs = [(ds, "asis", 0) for ds in DATASETS]
+    jobs += [(ds, "spikes", s) for ds in DATASETS for s in range(SPIKE_SEEDS)]
+    results = []
+    if os.path.exists(args.out):
+        with open(args.out) as fh:
+            results = [json.loads(line) for line in fh if line.strip()]
+        done = {(r["ds"], r["variant"], r["seed"]) for r in results}
+        jobs = [j for j in jobs if j not in done]
+        print(f"resuming: {len(results)} done, {len(jobs)} to go", flush=True)
+
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(run_one, jobs)):
+            results.append(res)
+            with open(args.out, "a") as fh:
+                fh.write(json.dumps(res) + "\n")
+            print(f"[{i + 1}/{len(jobs)}] {res['ds']:18s} {res['variant']:6s} "
+                  f"seed {res['seed']:<2d} {res['seconds']:6.1f}s", flush=True)
+
+    summarize(results)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/regression_frontend.py
+++ b/benchmarks/regression_frontend.py
@@ -1,0 +1,476 @@
+"""Regression front-end: does the Laplace sandwich fix online regression?
+
+The sequel to the detector/forecaster front-end studies (RESULTS.md sections
+1-2), with "detector" replaced by "regressor". Thesis under test:
+
+    Run every input stream and the target stream through its own Laplace
+    body and regress in parade-z coordinates. The margins are conditional
+    predictive CDFs, so each z stream is calibrated, stationary in scale and
+    bounded in influence; the regression learns only cross-stream dependence
+    (a dynamic Gaussian copula). Predictions map back through the target
+    body's predictive distribution, point value by quadrature.
+
+This harness is the contaminated-simulation prong. One fixed dumb learner
+(recursive least squares with forgetting) is run under different coordinate
+systems on the same synthetic streams; only the coordinates vary. The core
+process is a linear Gaussian pair
+
+    x_t = 0.8 x_{t-1} + e_t
+    y_t = 0.7 y_{t-1} + 1.0 x_{t-1} + 0.5 n_t
+
+one-step prequential prediction of y_t, contaminated along one axis per
+scenario so we learn which failure mode each fix actually repairs:
+
+    clean       nothing (measures the efficiency toll of each fix)
+    spikes_x    2% measurement spikes on observed x, 6-10 sigma
+    spikes_y    same on observed y
+    spikes_both both
+    heavy       e and n drawn t(2): infinite-variance driving noise
+    drift       noise scales ramp x7 across the series
+    distort     regressor observes sinh(x): monotone marginal distortion
+                (the nonparanormal generative model); y driven by latent x
+    shift       +6 level shift in x at 60%, propagating to y (recovery
+                window scored separately)
+
+Conditions (same RLS everywhere; z from ``laplace(1)`` parade state):
+
+    laplace     target body alone, no regression (does x add anything?)
+    raw         y_t ~ [1, y_{t-1}, x_{t-1}]
+    zscore      same, all variables EWMA-standardized, affine map back
+                (the RevIN-style affine special case)
+    robust      median/MAD standardized + winsorized at 4 robust units
+    huber       raw coordinates, RLS residual clipped in the update
+                (fix the loss instead of the coordinates)
+    zin         inputs fixed: y_t ~ [1, mu_y, z_y, mu_x, z_x] (body
+                predictive means + calibrated surprises)
+    zout        output fixed: z_y(t) ~ standardized raw inputs, mapped
+                back through the y-body's predictive CDF by quadrature
+    sandwich    both: z_y(t) ~ [1, z_y(t-1), z_x(t-1)], quadrature back
+
+Metrics, per (scenario, seed): MSE and MAE against the conditional mean of
+the clean process (excess risk; the oracle is the zero point), CRPS against
+the clean y. CRPS uses the same 33-node quantile/pinball estimator for every
+condition (closed-form quantiles for the Gaussian conditions, a per-tick
+inverse-CDF grid for the mixture conditions), so the estimator bias is
+shared. Primary metric is MSE vs the conditional mean.
+
+Strictly causal, one pass, no whole-series normalisation. Resumable jsonl,
+one line per (scenario, seed).
+
+Usage:
+    python benchmarks/regression_frontend.py --seeds 30 --workers 4
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+import zlib
+import random as _random
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+
+N = 1200
+BURN = 300
+PHI_Y, BETA, PHI_X, SIG_Y = 0.7, 1.0, 0.8, 0.5
+SCENARIOS = ("clean", "spikes_x", "spikes_y", "spikes_both",
+             "heavy", "drift", "distort", "shift")
+CONDS = ("laplace", "raw", "zscore", "robust", "huber",
+         "zin", "zout", "sandwich")
+
+# 33 mid-quantile nodes and their standard-normal abscissae (Acklam-free:
+# bisection on erf once at import).
+_M = 33
+_US = [(i + 0.5) / _M for i in range(_M)]
+
+
+def _norm_ppf(p: float) -> float:
+    lo, hi = -8.0, 8.0
+    for _ in range(80):
+        mid = 0.5 * (lo + hi)
+        if 0.5 * (1.0 + math.erf(mid / math.sqrt(2.0))) < p:
+            lo = mid
+        else:
+            hi = mid
+    return 0.5 * (lo + hi)
+
+
+_ZS = [_norm_ppf(u) for u in _US]
+
+
+def _norm_cdf(z: float) -> float:
+    return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
+
+
+# ---------------------------------------------------------------- data
+
+
+def _t2(rng):
+    """Student t, 2 degrees of freedom: N / sqrt(chi2_2 / 2)."""
+    chi2 = -2.0 * math.log(max(rng.random(), 1e-300))
+    return rng.gauss(0.0, 1.0) / math.sqrt(chi2 / 2.0)
+
+
+def make_series(scenario: str, seed: int):
+    """Returns (obs_x, obs_y, m, y_clean, tau).
+
+    m[t] is the conditional mean of clean y_t given the clean past (the
+    oracle predictor); tau is the shift onset or None.
+    """
+    rng = _random.Random(zlib.crc32(f"{scenario}:{seed}".encode()))
+    heavy = scenario == "heavy"
+    tau = int(0.6 * N) if scenario == "shift" else None
+    x = [0.0] * N
+    y = [0.0] * N
+    m = [0.0] * N
+    for t in range(1, N):
+        s = math.exp(2.0 * t / N) / math.e if scenario == "drift" else 1.0
+        e = (_t2(rng) if heavy else rng.gauss(0.0, 1.0)) * s
+        n = (_t2(rng) if heavy else rng.gauss(0.0, 1.0)) * s
+        x[t] = PHI_X * x[t - 1] + e
+        if tau is not None and t >= tau:
+            x[t] += 6.0 * (1.0 - PHI_X)      # shifts the process mean by +6
+        m[t] = PHI_Y * y[t - 1] + BETA * x[t - 1]
+        y[t] = m[t] + SIG_Y * n
+    obs_x, obs_y = list(x), list(y)
+    if scenario == "distort":
+        obs_x = [math.sinh(v) for v in x]
+    if scenario in ("spikes_x", "spikes_both"):
+        sx = _pstd(x)
+        for t in range(1, N):
+            if rng.random() < 0.02:
+                obs_x[t] = x[t] + (6.0 + 4.0 * rng.random()) * sx * rng.choice((-1, 1))
+    if scenario in ("spikes_y", "spikes_both"):
+        sy = _pstd(y)
+        for t in range(1, N):
+            if rng.random() < 0.02:
+                obs_y[t] = y[t] + (6.0 + 4.0 * rng.random()) * sy * rng.choice((-1, 1))
+    return obs_x, obs_y, m, y, tau
+
+
+def _pstd(v):
+    mu = sum(v) / len(v)
+    return math.sqrt(sum((a - mu) ** 2 for a in v) / len(v)) or 1e-8
+
+
+# ---------------------------------------------------------------- pieces
+
+
+class RLS:
+    """Recursive least squares with exponential forgetting."""
+
+    def __init__(self, d, lam=0.999, p0=100.0):
+        self.d, self.lam = d, lam
+        self.w = [0.0] * d
+        self.P = [[(p0 if i == j else 0.0) for j in range(d)] for i in range(d)]
+
+    def predict(self, phi):
+        return sum(w * p for w, p in zip(self.w, phi))
+
+    def update(self, phi, target, clip=None):
+        err = target - self.predict(phi)
+        if clip is not None:
+            err = max(-clip, min(clip, err))
+        Pp = [sum(self.P[i][j] * phi[j] for j in range(self.d))
+              for i in range(self.d)]
+        denom = self.lam + sum(p * pp for p, pp in zip(phi, Pp))
+        g = [pp / denom for pp in Pp]
+        for i in range(self.d):
+            self.w[i] += g[i] * err
+        for i in range(self.d):
+            for j in range(self.d):
+                self.P[i][j] = (self.P[i][j] - g[i] * Pp[j]) / self.lam
+        # windup guard, as in skaters' ar(): reset on inflation/non-finite
+        tr = sum(self.P[i][i] for i in range(self.d))
+        if not math.isfinite(tr) or tr > 1e7:
+            self.__init__(self.d, self.lam)
+
+
+class Ewma:
+    def __init__(self, alpha=0.02):
+        self.a, self.m, self.v, self.n = alpha, 0.0, 1.0, 0
+
+    def std(self):
+        # unit scale until warm: the first few updates collapse v toward 0
+        # (n=1 sets it exactly to 0) and a tiny floor would explode features
+        if self.n < 10 or self.v <= 1e-8:
+            return 1.0
+        return math.sqrt(self.v)
+
+    def update(self, x):
+        self.n += 1
+        a = max(self.a, 1.0 / self.n)
+        d = x - self.m
+        self.m += a * d
+        self.v = (1 - a) * self.v + a * d * (x - self.m)
+
+
+class RobustScale:
+    """Streaming median/MAD (FAME-style)."""
+
+    def __init__(self, eta=0.05):
+        self.eta, self.med, self.mad, self.n = eta, 0.0, 1.0, 0
+
+    def update(self, x):
+        self.n += 1
+        step = self.eta * self.mad if self.n > 5 else abs(x - self.med) + 1e-8
+        self.med += step if x > self.med else -step
+        self.mad = (1 - self.eta) * self.mad + self.eta * abs(x - self.med)
+        self.mad = max(self.mad, 1e-6)
+
+
+def inverse_cdf_grid(dist, points=256):
+    """Monotone inverse CDF of a Dist by interpolation on a cdf grid."""
+    d = dist.prune(12)
+    lo = min(m - 8 * s for _, m, s in d.components)
+    hi = max(m + 8 * s for _, m, s in d.components)
+    if hi <= lo:
+        hi = lo + 1e-6
+    xs = [lo + (hi - lo) * i / (points - 1) for i in range(points)]
+    cs = [d.cdf(v) for v in xs]
+
+    def q(u):
+        if u <= cs[0]:
+            return xs[0]
+        if u >= cs[-1]:
+            return xs[-1]
+        lo_i, hi_i = 0, points - 1
+        while hi_i - lo_i > 1:
+            mid = (lo_i + hi_i) // 2
+            if cs[mid] < u:
+                lo_i = mid
+            else:
+                hi_i = mid
+        c0, c1 = cs[lo_i], cs[hi_i]
+        w = (u - c0) / (c1 - c0) if c1 > c0 else 0.5
+        return xs[lo_i] + w * (xs[hi_i] - xs[lo_i])
+
+    return q
+
+
+def pinball_crps(quantiles, y):
+    """CRPS approximated as 2/m * sum of pinball losses on the _US grid."""
+    total = 0.0
+    for u, q in zip(_US, quantiles):
+        total += (y - q) * u if y >= q else (q - y) * (1 - u)
+    return 2.0 * total / _M
+
+
+# ---------------------------------------------------------------- run one
+
+
+def body_pass(series):
+    """One Laplace(1) pass: surprise z[t] and the predictive Dist for the
+    NEXT point (preds[t] = distribution for time t, issued at t-1)."""
+    from timemachines import laplace
+    f = laplace(1)
+    st = None
+    zs = [None] * len(series)
+    preds = [None] * (len(series) + 1)
+    for t, v in enumerate(series):
+        dists, st = f(v, st)
+        zs[t] = st["z"][0]
+        preds[t + 1] = dists[0]
+    return zs, preds
+
+
+def run_one(job):
+    scenario, seed = job
+
+    obs_x, obs_y, m, y_clean, tau = make_series(scenario, seed)
+    t0 = time.time()
+
+    zy, ypred = body_pass(obs_y)
+    zx, xpred = body_pass(obs_x)
+
+    learners = {
+        "raw": RLS(3), "zscore": RLS(3), "robust": RLS(3), "huber": RLS(3),
+        "zin": RLS(5), "zout": RLS(3), "sandwich": RLS(3),
+    }
+    sc_y, sc_x = Ewma(), Ewma()                    # zscore trackers
+    rb_y, rb_x = RobustScale(), RobustScale()      # robust trackers
+    rvar = {c: Ewma() for c in CONDS if c != "laplace"}   # resid vars
+    hub_scale = RobustScale()                      # huber residual scale
+
+    acc = {c: {"se": 0.0, "ae": 0.0, "crps": 0.0, "n": 0} for c in CONDS}
+    post = {c: {"se": 0.0, "n": 0} for c in CONDS}
+
+    for t in range(2, N):
+        y1, x1 = obs_y[t - 1], obs_x[t - 1]
+        zy1 = zy[t - 1] if zy[t - 1] is not None else 0.0
+        zx1 = zx[t - 1] if zx[t - 1] is not None else 0.0
+        yd = ypred[t]
+        mu_y, mu_x = yd.mean, xpred[t].mean
+
+        ys_m, ys_s = sc_y.m, sc_y.std()
+        xs_m, xs_s = sc_x.m, sc_x.std()
+        yr_m, yr_s = rb_y.med, 1.4826 * rb_y.mad
+        xr_m, xr_s = rb_x.med, 1.4826 * rb_x.mad
+
+        feats = {
+            "raw": [1.0, y1, x1],
+            "zscore": [1.0, (y1 - ys_m) / ys_s, (x1 - xs_m) / xs_s],
+            "robust": [1.0,
+                       max(-4.0, min(4.0, (y1 - yr_m) / yr_s)),
+                       max(-4.0, min(4.0, (x1 - xr_m) / xr_s))],
+            "huber": [1.0, y1, x1],
+            "zin": [1.0, mu_y, zy1, mu_x, zx1],
+            "zout": [1.0, (y1 - ys_m) / ys_s, (x1 - xs_m) / xs_s],
+            "sandwich": [1.0, zy1, zx1],
+        }
+
+        qgrid = inverse_cdf_grid(yd)
+
+        preds, quants = {}, {}
+        preds["laplace"] = mu_y
+        quants["laplace"] = [qgrid(u) for u in _US]
+        for c in ("raw", "huber", "zin"):
+            p = learners[c].predict(feats[c])
+            s = rvar[c].std()
+            preds[c] = p
+            quants[c] = [p + s * z for z in _ZS]
+        p = learners["zscore"].predict(feats["zscore"])
+        s = rvar["zscore"].std() * ys_s
+        preds["zscore"] = ys_m + ys_s * p
+        quants["zscore"] = [preds["zscore"] + s * z for z in _ZS]
+        p = learners["robust"].predict(feats["robust"])
+        s = rvar["robust"].std() * yr_s
+        preds["robust"] = yr_m + yr_s * p
+        quants["robust"] = [preds["robust"] + s * z for z in _ZS]
+        for c in ("zout", "sandwich"):
+            zhat = learners[c].predict(feats[c])
+            sz = min(rvar[c].std(), 3.0)
+            qs = [qgrid(_norm_cdf(zhat + sz * z)) for z in _ZS]
+            preds[c] = sum(qs) / _M          # quadrature: mean of pushforward
+            quants[c] = qs
+
+        if t >= BURN:
+            for c in CONDS:
+                a = acc[c]
+                a["se"] += (preds[c] - m[t]) ** 2
+                a["ae"] += abs(preds[c] - m[t])
+                a["crps"] += pinball_crps(quants[c], y_clean[t])
+                a["n"] += 1
+            if tau is not None and tau <= t < tau + 80:
+                for c in CONDS:
+                    post[c]["se"] += (preds[c] - m[t]) ** 2
+                    post[c]["n"] += 1
+
+        # --- updates (after prediction: prequential) ---
+        yt = obs_y[t]
+        for c in ("raw", "zin"):
+            rvar[c].update(yt - preds[c])
+            learners[c].update(feats[c], yt)
+        r = yt - preds["huber"]
+        hub_scale.update(r)
+        rvar["huber"].update(r)
+        learners["huber"].update(feats["huber"], yt,
+                                 clip=2.5 * 1.4826 * hub_scale.mad)
+        tgt = (yt - ys_m) / ys_s
+        rvar["zscore"].update(tgt - learners["zscore"].predict(feats["zscore"]))
+        learners["zscore"].update(feats["zscore"], tgt)
+        tgt = max(-4.0, min(4.0, (yt - yr_m) / yr_s))
+        rvar["robust"].update(tgt - learners["robust"].predict(feats["robust"]))
+        learners["robust"].update(feats["robust"], tgt)
+        if zy[t] is not None:
+            for c in ("zout", "sandwich"):
+                rvar[c].update(zy[t] - learners[c].predict(feats[c]))
+                learners[c].update(feats[c], zy[t])
+        sc_y.update(yt)
+        sc_x.update(obs_x[t])
+        rb_y.update(yt)
+        rb_x.update(obs_x[t])
+
+    res = {"scenario": scenario, "seed": seed, "n": N}
+    for c in CONDS:
+        a = acc[c]
+        res[c] = {"mse": a["se"] / a["n"], "mae": a["ae"] / a["n"],
+                  "crps": a["crps"] / a["n"]}
+        if tau is not None and post[c]["n"]:
+            res[c]["mse_post"] = post[c]["se"] / post[c]["n"]
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+# ---------------------------------------------------------------- main
+
+
+def summarize(results):
+    print(f"\n=== regression front-end, excess MSE vs conditional mean "
+          f"(median over seeds; n={len(results)} rows) ===")
+    for metric in ("mse", "crps"):
+        print(f"\n--- {metric} ---")
+        print(f"{'scenario':12s} " + " ".join(f"{c:>9s}" for c in CONDS))
+        for sc in SCENARIOS:
+            rows = [r for r in results if r["scenario"] == sc]
+            if not rows:
+                continue
+            line = f"{sc:12s} "
+            for c in CONDS:
+                vals = sorted(r[c][metric] for r in rows)
+                line += f"{vals[len(vals) // 2]:9.4f} "
+            print(line)
+    rows = [r for r in results if r["scenario"] == "shift"
+            and "mse_post" in r["raw"]]
+    if rows:
+        print("\n--- shift recovery (median MSE, 80 ticks post-onset) ---")
+        line = f"{'shift+80':12s} "
+        for c in CONDS:
+            vals = sorted(r[c]["mse_post"] for r in rows)
+            line += f"{vals[len(vals) // 2]:9.4f} "
+        print(line)
+    print("\n--- wins vs raw on mse (per scenario, out of seeds) ---")
+    print(f"{'scenario':12s} " + " ".join(f"{c:>9s}" for c in CONDS))
+    for sc in SCENARIOS:
+        rows = [r for r in results if r["scenario"] == sc]
+        if not rows:
+            continue
+        line = f"{sc:12s} "
+        for c in CONDS:
+            w = sum(1 for r in rows if r[c]["mse"] < r["raw"]["mse"])
+            line += f"{w:>7d}/{len(rows):<2d}"
+        print(line)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seeds", type=int, default=30)
+    ap.add_argument("--workers", type=int, default=4)
+    ap.add_argument("--scenarios", type=str, default="")
+    ap.add_argument("--out", type=str,
+                    default=os.path.join(_HERE, "regression_frontend_results.jsonl"))
+    args = ap.parse_args()
+
+    scens = [s for s in args.scenarios.split(",") if s] or list(SCENARIOS)
+    jobs = [(sc, sd) for sc in scens for sd in range(args.seeds)]
+
+    results = []
+    if os.path.exists(args.out):
+        with open(args.out) as fh:
+            results = [json.loads(line) for line in fh if line.strip()]
+        done = {(r["scenario"], r["seed"]) for r in results}
+        jobs = [j for j in jobs if j not in done]
+        print(f"resuming: {len(results)} done in {args.out}, "
+              f"{len(jobs)} to go", flush=True)
+
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(run_one, jobs)):
+            results.append(res)
+            with open(args.out, "a") as fh:
+                fh.write(json.dumps(res) + "\n")
+            print(f"[{i + 1}/{len(jobs)}] {res['scenario']:12s} "
+                  f"seed {res['seed']:<3d} {res['seconds']:5.1f}s  "
+                  f"raw {res['raw']['mse']:7.3f}  "
+                  f"sand {res['sandwich']['mse']:7.3f}", flush=True)
+
+    summarize(results)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/river_data_frontend.py
+++ b/benchmarks/river_data_frontend.py
@@ -1,0 +1,252 @@
+"""River real-data front-end: the ticket-gate experiment.
+
+`river_frontend.py` established the lift on simulated contamination. This
+harness repeats the question on river's own regression datasets with
+river's progressive-validation protocol (predict, score, then learn):
+does the Laplace front-end beat river's recommended standardization
+pipeline where a river user would actually stand?
+
+Datasets (numeric features only, identical treatment for every condition;
+strings/datetimes dropped symmetrically — disclosed, not hidden):
+
+    TrumpApproval      1,001 samples, 6 numeric features
+    ChickWeights         578 samples, 3 numeric features
+    AirlinePassengers    144 samples, 1 numeric feature
+    Bikes             20,000 samples (capped from 182,470 — logged), 5
+                       numeric weather features, stations interleaved
+
+Variants:
+    asis     the dataset untouched (does real-world dirt alone pay for
+             the front-end, or does the clean toll win?)
+    spikes   2% measurement spikes, 6-10 full-sample sigmas, injected on
+             numeric FEATURES only (never the target; scoring stays
+             against the real y), 10 seeds — the insurance claim on real
+             backgrounds, as in fred_anomaly.py
+
+Learners: river LinearRegression and HoeffdingTreeRegressor at defaults
+(KNN excluded: established counterexample, see RESULTS.md section 6).
+Conditions per learner:
+
+    std     TargetStandardScaler(StandardScaler | learner) on raw numeric
+            features — river's existing pipeline
+    lapin   same pipeline, features replaced by per-stream Laplace body
+            representations (predictive mean + parade z), target body's
+            mean and surprise appended
+    sand    StandardScaler | learner predicting the target's parade z,
+            plug-in map back through the target body's predictive CDF
+
+A body-alone reference column (the target's Laplace predictive mean,
+no regression, no features) is scored alongside: it attributes each win
+to the body vs the regression on top of it.
+
+Metric: MAE (river's convention) and MSE against the true target,
+progressive validation, burn-in max(30, min(300, n/10)). Resumable jsonl.
+
+Usage:
+    python benchmarks/river_data_frontend.py --workers 6
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+import zlib
+import random as _random
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from regression_frontend import inverse_cdf_grid, _norm_cdf  # noqa: E402
+
+DATASETS = ("TrumpApproval", "ChickWeights", "AirlinePassengers", "Bikes")
+CAP = 20000
+LEARNERS = ("lin", "tree")
+CONDS = ("std", "lapin", "sand")
+SPIKE_SEEDS = 10
+
+
+def _load(dsname):
+    from river import datasets
+    rows = []
+    for x, y in getattr(datasets, dsname)():
+        rows.append((x, float(y)))
+        if len(rows) >= CAP:
+            break
+    numeric = [k for k, v in rows[0][0].items()
+               if isinstance(v, (int, float)) and not isinstance(v, bool)]
+    return rows, numeric
+
+
+def _make(learner, cond):
+    from river import linear_model, preprocessing, tree
+    base = {"lin": linear_model.LinearRegression,
+            "tree": tree.HoeffdingTreeRegressor}[learner]()
+    scaled = preprocessing.StandardScaler() | base
+    if cond in ("std", "lapin"):
+        return preprocessing.TargetStandardScaler(regressor=scaled)
+    return scaled                                    # sand: z target
+
+
+def run_one(job):
+    dsname, variant, seed = job
+    from timemachines import laplace
+
+    rows, numeric = _load(dsname)
+    n = len(rows)
+    burn = max(30, min(300, n // 10))
+    t0 = time.time()
+
+    xs = [{k: float(x[k]) for k in numeric} for x, _ in rows]
+    ys = [y for _, y in rows]
+    if variant == "spikes":
+        rng = _random.Random(zlib.crc32(f"{dsname}:{seed}".encode()))
+        for k in numeric:
+            col = [r[k] for r in xs]
+            mu = sum(col) / n
+            sd = math.sqrt(sum((v - mu) ** 2 for v in col) / n) or 1e-8
+            for t in range(n):
+                if rng.random() < 0.02:
+                    xs[t][k] = col[t] + (6.0 + 4.0 * rng.random()) * sd \
+                        * rng.choice((-1, 1))
+
+    models = {(lr, c): _make(lr, c) for lr in LEARNERS for c in CONDS}
+    acc = {k: {"se": 0.0, "ae": 0.0, "n": 0} for k in models}
+    bacc = {"se": 0.0, "ae": 0.0, "n": 0}
+
+    y_body, y_st = laplace(1), None
+    f_bodies = {k: (laplace(1), None) for k in numeric}
+    f_prev = {k: None for k in numeric}              # predictive Dist for x_t
+    y_prev = None                                    # predictive Dist for y_t
+    zy_prev = 0.0
+
+    for t in range(n):
+        # feature bodies consume x_t (known at prediction time)
+        rep = {}
+        for k in numeric:
+            body, st = f_bodies[k]
+            mu = f_prev[k].mean if f_prev[k] is not None else xs[t][k]
+            dists, st = body(xs[t][k], st)
+            f_bodies[k] = (body, st)
+            z = st["z"][0]
+            rep[k] = (mu, z if z is not None else 0.0)
+            f_prev[k] = dists[0]
+        mu_y = y_prev.mean if y_prev is not None else 0.0
+
+        feats = {
+            "std": xs[t],
+            "lapin": {**{f"mu_{k}": rep[k][0] for k in numeric},
+                      **{f"z_{k}": rep[k][1] for k in numeric},
+                      "mu_y": mu_y, "zy": zy_prev},
+            "sand": {**{f"z_{k}": rep[k][1] for k in numeric},
+                     "zy": zy_prev},
+        }
+        qgrid = inverse_cdf_grid(y_prev) if y_prev is not None else None
+        if t >= burn:
+            bacc["se"] += (mu_y - ys[t]) ** 2
+            bacc["ae"] += abs(mu_y - ys[t])
+            bacc["n"] += 1
+
+        preds = {}
+        for (lr, c), model in models.items():
+            p = model.predict_one(feats[c])
+            p = p if p is not None else 0.0
+            if c == "sand":
+                p = qgrid(_norm_cdf(max(-7.0, min(7.0, p)))) \
+                    if qgrid is not None else 0.0
+            preds[(lr, c)] = p
+            if t >= burn:
+                acc[(lr, c)]["se"] += (p - ys[t]) ** 2
+                acc[(lr, c)]["ae"] += abs(p - ys[t])
+                acc[(lr, c)]["n"] += 1
+
+        # learn: target body first (sand needs z of y_t), then the models
+        dists, y_st = y_body(ys[t], y_st)
+        zy_t = y_st["z"][0]
+        for (lr, c), model in models.items():
+            if c == "sand":
+                if zy_t is not None:
+                    model.learn_one(feats[c], zy_t)
+            else:
+                model.learn_one(feats[c], ys[t])
+        y_prev = dists[0]
+        zy_prev = zy_t if zy_t is not None else 0.0
+
+    res = {"ds": dsname, "variant": variant, "seed": seed,
+           "n": n, "burn": burn}
+    for (lr, c), a in acc.items():
+        res[f"{lr}_{c}"] = {"mae": a["ae"] / a["n"], "mse": a["se"] / a["n"]}
+    res["body"] = {"mae": bacc["ae"] / bacc["n"], "mse": bacc["se"] / bacc["n"]}
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+def summarize(results):
+    print(f"\n=== river real data, MAE progressive validation "
+          f"(n={len(results)} rows) ===")
+    for variant in ("asis", "spikes"):
+        rows_v = [r for r in results if r["variant"] == variant]
+        if not rows_v:
+            continue
+        print(f"\n--- {variant} ---")
+        for lr in LEARNERS:
+            print(f"{lr}: {'dataset':18s} "
+                  + " ".join(f"{c:>9s}" for c in CONDS)
+                  + f" {'body':>9s} {'lapin>std':>10s}")
+            for ds in DATASETS:
+                rows = [r for r in rows_v if r["ds"] == ds]
+                if not rows:
+                    continue
+                line = f"    {ds:18s} "
+                for c in CONDS:
+                    vals = sorted(r[f"{lr}_{c}"]["mae"] for r in rows)
+                    line += f"{vals[len(vals) // 2]:9.3f} "
+                bv = sorted(r["body"]["mae"] for r in rows)
+                line += f"{bv[len(bv) // 2]:9.3f} "
+                w = sum(1 for r in rows
+                        if r[f"{lr}_lapin"]["mae"] < r[f"{lr}_std"]["mae"])
+                line += f" {w:>6d}/{len(rows):<3d}"
+                print(line)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--out", type=str,
+                    default=os.path.join(_HERE,
+                                         "river_data_frontend_results.jsonl"))
+    args = ap.parse_args()
+
+    jobs = [(ds, "asis", 0) for ds in DATASETS]
+    jobs += [(ds, "spikes", s) for ds in DATASETS for s in range(SPIKE_SEEDS)]
+
+    results = []
+    if os.path.exists(args.out):
+        with open(args.out) as fh:
+            results = [json.loads(line) for line in fh if line.strip()]
+        done = {(r["ds"], r["variant"], r["seed"]) for r in results}
+        jobs = [j for j in jobs if j not in done]
+        print(f"resuming: {len(results)} done in {args.out}, "
+              f"{len(jobs)} to go", flush=True)
+
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(run_one, jobs)):
+            results.append(res)
+            with open(args.out, "a") as fh:
+                fh.write(json.dumps(res) + "\n")
+            print(f"[{i + 1}/{len(jobs)}] {res['ds']:18s} "
+                  f"{res['variant']:6s} seed {res['seed']:<2d} "
+                  f"{res['seconds']:6.1f}s  "
+                  f"lin std {res['lin_std']['mae']:8.3f}  "
+                  f"lin lapin {res['lin_lapin']['mae']:8.3f}", flush=True)
+
+    summarize(results)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/river_frontend.py
+++ b/benchmarks/river_frontend.py
@@ -1,0 +1,169 @@
+"""River front-end: the Laplace sandwich vs river's standardization pipeline.
+
+Section 6 (`regression_frontend.py`) held the learner fixed (our RLS) and
+varied coordinates. This harness flips it: the learners are third-party —
+river's, the reference streaming-ML library — and the baseline is river's
+own recommended preprocessing, `StandardScaler` on features plus
+`TargetStandardScaler` on the target. The question a river ticket would
+need answered: does a Laplace front-end lift river's learners over river's
+existing pipeline, on the same streams?
+
+Same generator, scenarios and metric as regression_frontend.py (excess MSE
+vs the clean conditional mean). Learners: LinearRegression (SGD),
+HoeffdingTreeRegressor, KNNRegressor, each at river defaults. Conditions:
+
+    raw     bare learner on {y_{t-1}, x_{t-1}}
+    std     TargetStandardScaler(StandardScaler | learner), same features
+            (river's existing standardization pipeline)
+    lapin   the SAME std pipeline, features replaced by the Laplace bodies'
+            representation {mu_y, z_y, mu_x, z_x} — the front-end composes
+            with, not replaces, their pipeline
+    sand    StandardScaler | learner predicting z_y from {z_y, z_x},
+            mapped back through the y-body's predictive CDF. Plug-in
+            point map (river learners are point predictors, so no
+            quadrature; this is the median-flavoured map, biased for the
+            mean under skew — disclosed, not corrected)
+
+Strictly causal, prequential (predict, score, then learn). Resumable jsonl.
+
+Usage:
+    python benchmarks/river_frontend.py --seeds 30 --workers 6
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import os
+import sys
+import time
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from regression_frontend import (  # noqa: E402
+    N, BURN, SCENARIOS, make_series, body_pass, inverse_cdf_grid, _norm_cdf)
+
+LEARNERS = ("lin", "tree", "knn")
+CONDS = ("raw", "std", "lapin", "sand")
+
+
+def _make(learner, cond):
+    from river import linear_model, preprocessing, tree, neighbors
+    base = {"lin": linear_model.LinearRegression,
+            "tree": tree.HoeffdingTreeRegressor,
+            "knn": neighbors.KNNRegressor}[learner]()
+    if cond == "raw":
+        return base
+    scaled = preprocessing.StandardScaler() | base
+    if cond in ("std", "lapin"):
+        return preprocessing.TargetStandardScaler(regressor=scaled)
+    return scaled                                    # sand: z target, unit scale
+
+
+def run_one(job):
+    scenario, seed = job
+    obs_x, obs_y, m, y_clean, tau = make_series(scenario, seed)
+    t0 = time.time()
+
+    zy, ypred = body_pass(obs_y)
+    zx, xpred = body_pass(obs_x)
+
+    models = {(lr, c): _make(lr, c) for lr in LEARNERS for c in CONDS}
+    acc = {k: {"se": 0.0, "ae": 0.0, "n": 0} for k in models}
+
+    for t in range(2, N):
+        zy1 = zy[t - 1] if zy[t - 1] is not None else 0.0
+        zx1 = zx[t - 1] if zx[t - 1] is not None else 0.0
+        feats = {
+            "raw": {"y1": obs_y[t - 1], "x1": obs_x[t - 1]},
+            "std": {"y1": obs_y[t - 1], "x1": obs_x[t - 1]},
+            "lapin": {"mu_y": ypred[t].mean, "zy": zy1,
+                      "mu_x": xpred[t].mean, "zx": zx1},
+            "sand": {"zy": zy1, "zx": zx1},
+        }
+        qgrid = inverse_cdf_grid(ypred[t])
+
+        for (lr, c), model in models.items():
+            p = model.predict_one(feats[c])
+            p = p if p is not None else 0.0
+            if c == "sand":
+                p = qgrid(_norm_cdf(max(-7.0, min(7.0, p))))
+            if t >= BURN:
+                acc[(lr, c)]["se"] += (p - m[t]) ** 2
+                acc[(lr, c)]["ae"] += abs(p - m[t])
+                acc[(lr, c)]["n"] += 1
+            if c == "sand":
+                if zy[t] is not None:
+                    model.learn_one(feats[c], zy[t])
+            else:
+                model.learn_one(feats[c], obs_y[t])
+
+    res = {"scenario": scenario, "seed": seed, "n": N}
+    for (lr, c), a in acc.items():
+        res[f"{lr}_{c}"] = {"mse": a["se"] / a["n"], "mae": a["ae"] / a["n"]}
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+def summarize(results):
+    print(f"\n=== river front-end, excess MSE vs conditional mean "
+          f"(median over seeds; n={len(results)} rows) ===")
+    for lr in LEARNERS:
+        print(f"\n--- learner: {lr} ---")
+        print(f"{'scenario':12s} " + " ".join(f"{c:>9s}" for c in CONDS)
+              + f" {'lapin>std':>10s} {'sand>std':>9s}")
+        for sc in SCENARIOS:
+            rows = [r for r in results if r["scenario"] == sc]
+            if not rows:
+                continue
+            line = f"{sc:12s} "
+            for c in CONDS:
+                vals = sorted(r[f"{lr}_{c}"]["mse"] for r in rows)
+                line += f"{vals[len(vals) // 2]:9.3f} "
+            w1 = sum(1 for r in rows
+                     if r[f"{lr}_lapin"]["mse"] < r[f"{lr}_std"]["mse"])
+            w2 = sum(1 for r in rows
+                     if r[f"{lr}_sand"]["mse"] < r[f"{lr}_std"]["mse"])
+            line += f" {w1:>6d}/{len(rows):<3d} {w2:>5d}/{len(rows):<3d}"
+            print(line)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seeds", type=int, default=30)
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--scenarios", type=str, default="")
+    ap.add_argument("--out", type=str,
+                    default=os.path.join(_HERE, "river_frontend_results.jsonl"))
+    args = ap.parse_args()
+
+    scens = [s for s in args.scenarios.split(",") if s] or list(SCENARIOS)
+    jobs = [(sc, sd) for sc in scens for sd in range(args.seeds)]
+
+    results = []
+    if os.path.exists(args.out):
+        with open(args.out) as fh:
+            results = [json.loads(line) for line in fh if line.strip()]
+        done = {(r["scenario"], r["seed"]) for r in results}
+        jobs = [j for j in jobs if j not in done]
+        print(f"resuming: {len(results)} done in {args.out}, "
+              f"{len(jobs)} to go", flush=True)
+
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(run_one, jobs)):
+            results.append(res)
+            with open(args.out, "a") as fh:
+                fh.write(json.dumps(res) + "\n")
+            print(f"[{i + 1}/{len(jobs)}] {res['scenario']:12s} "
+                  f"seed {res['seed']:<3d} {res['seconds']:5.1f}s  "
+                  f"lin std {res['lin_std']['mse']:7.3f}  "
+                  f"lin lapin {res['lin_lapin']['mse']:7.3f}", flush=True)
+
+    summarize(results)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 [project.optional-dependencies]
 # Third-party detector heads and benchmark harnesses live behind extras;
 # the core is pure stdlib on top of skaters.
-benchmarks = ["rrcf", "statsforecast", "statsmodels", "arch", "prophet"]
+benchmarks = ["rrcf", "statsforecast", "statsmodels", "arch", "prophet", "river"]
 
 [project.urls]
 Homepage = "https://github.com/microprediction/timemachines"

--- a/src/timemachines/heads/mahalanobis.py
+++ b/src/timemachines/heads/mahalanobis.py
@@ -327,10 +327,14 @@ def mahalanobis(base, k: int, alpha: float = 0.02, scatter: str = "factor",
     assert scatter in ("factor", "shrink")
     assert factors >= 1
     assert dfloor > 0.0
+    assert min_exc >= 2, "min_exc < 2 divides by zero in the GPD fit"
+    assert 0.0 < pot_level < 1.0
+    assert 0.0 < guard_p < 1.0
 
     def _skater(y: float, state: dict | None):
         if state is None:
             state = {
+                "k": k,
                 "base": None,
                 "mu": [0.0] * k,                     # calibrated prior mean
                 "S": [1.0 if i == j else 0.0         # calibrated prior scatter
@@ -350,6 +354,10 @@ def mahalanobis(base, k: int, alpha: float = 0.02, scatter: str = "factor",
                 "run": 0, "d2": None, "pvalue": None,
                 "skipped": 0, "last_dists": None,
             }
+        elif state.get("k", k) != k:
+            raise ValueError(
+                f"state was built for k={state['k']} but this head has k={k};"
+                " states are not interchangeable across k")
         # Harden the gate: a non-finite tick must not reach the body — a single
         # NaN poisons (or crashes) any forecaster's state permanently. Hold the
         # last forecasts, emit no score, count the skip, and carry on.
@@ -365,6 +373,23 @@ def mahalanobis(base, k: int, alpha: float = 0.02, scatter: str = "factor",
         if state["pend1"] is not None:
             lp = state["pend1"].logpdf(y)
             nlp = -lp if math.isfinite(lp) else 1e6
+        # Winsorize absurd finite magnitudes before the body: double
+        # arithmetic dies long before the float range ends (skaters' AR
+        # raises OverflowError on a 1e300 tick and goes NaN by 1e100).
+        # The parade z saturates at |z| = 7.03 anyway, so clamping at a
+        # million sigmas is decision-invariant for every score this head
+        # emits, and the deep-evidence channel above already saw raw y.
+        y = min(max(y, -1e60), 1e60)
+        if state["pend1"] is not None:
+            m0, s0 = state["pend1"].mean, state["pend1"].std
+            if math.isfinite(m0) and math.isfinite(s0):
+                # magnitude-relative, NOT sigma-relative: after a
+                # degenerate-variance stretch a legitimate value can sit
+                # billions of sigmas out and must pass. Twelve orders
+                # above the current level is unreachable by data, far
+                # below the ~1e77 jump ratio where doubles actually die.
+                w = 1e12 * (1.0 + abs(m0) + s0)
+                y = min(max(y, m0 - w), m0 + w)
         dists, state["base"] = base(y, state["base"])
         state["last_dists"] = dists
         state["pend1"] = dists[0]
@@ -374,7 +399,10 @@ def mahalanobis(base, k: int, alpha: float = 0.02, scatter: str = "factor",
             "mahalanobis requires a parade-wrapped skater exposing "
             "state['z'] of length k (e.g. skaters.laplace)")
 
-        if any(v is None for v in z):                # warmup / degenerate tick
+        # warmup / degenerate tick — and, for custom bases without the
+        # parade clamp, a non-finite z, which would otherwise poison the
+        # null moments permanently (inf -> m2/v2 -> nan nu next tick)
+        if any(v is None or not math.isfinite(v) for v in z):
             state["d2"] = None
             state["pvalue"] = None
             return dists, state

--- a/tests/test_extreme_inputs.py
+++ b/tests/test_extreme_inputs.py
@@ -1,0 +1,86 @@
+"""Extreme-input hardening: finite values must never kill the machine.
+
+The non-finite gate (NaN/inf skipped, forecasts held) predates these
+tests; what they pin down is the *finite* attack surface: double
+arithmetic inside any body dies long before the float range ends, so the
+head winsorizes at |y| = 1e60 and a million predictive sigmas — both far
+beyond the parade z saturation at |z| = 7.03, hence decision-invariant.
+"""
+
+import math
+
+import pytest
+
+from timemachines import laplace, mahalanobis, wald
+
+BASE = [math.sin(0.1 * t) for t in range(200)]
+
+
+def _feed(f, ys):
+    st = None
+    for y in ys:
+        dists, st = f(y, st)
+    return dists, st
+
+
+@pytest.mark.parametrize("ys", [
+    BASE + [1e300] + BASE,
+    [1e300] * 100,
+    [10.0 ** (t % 280) for t in range(300)],          # exponential ladder
+    [10.0 ** -(t % 280) for t in range(300)],         # collapse to tiny
+    BASE + [-1e300, 1e300] * 3 + BASE,
+    [1e59] * 50 + [1e60] * 50,
+    # the two cases that broke earlier clamp designs: a legitimate value
+    # arriving after a degenerate-variance stretch is billions of sigmas
+    # out and must NOT be clamped; ultra-predictable streams (collapsed
+    # predictive variance) must keep their legitimate steps
+    [0.0] * 100 + [35.0] + BASE,
+    [736000.0 + t for t in range(300)],
+], ids=["spike-1e300", "all-1e300", "ladder-up", "ladder-down",
+        "alternating", "near-clamp", "recovery-from-zeros",
+        "date-like-linear"])
+def test_huge_finite_values_never_crash_wald(ys):
+    dists, st = _feed(wald(3), ys)
+    assert st["pvalue"] is None or 0.0 <= st["pvalue"] <= 1.0
+    assert all(math.isfinite(d.mean) for d in dists)
+
+
+def test_spike_still_reads_as_maximal_surprise():
+    """The clamp must not blunt detection: a huge spike still saturates z."""
+    f, st = wald(3), None
+    for y in BASE:
+        _, st = f(y, st)
+    _, st = f(1e300, st)
+    assert abs(st["base"]["z"][0]) > 6.9
+
+
+def test_custom_base_with_non_finite_z_does_not_poison_null():
+    from skaters.dist import Dist
+
+    def bad_base(y, st):
+        st = st or {"n": 0}
+        st["n"] += 1
+        st["z"] = [float("inf"), 2.0] if st["n"] == 50 else [0.1, 0.2]
+        return [Dist.gaussian(0.0, 1.0)] * 2, st
+
+    f, st = mahalanobis(bad_base, k=2), None
+    for _ in range(120):
+        _, st = f(0.0, st)
+    assert st["pvalue"] is not None and 0.0 <= st["pvalue"] <= 1.0
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"min_exc": 1}, {"guard_p": 1.0}, {"guard_p": 0.0},
+    {"pot_level": 1.0}, {"pot_level": 0.0},
+])
+def test_bad_head_parameters_rejected_at_construction(kwargs):
+    with pytest.raises(AssertionError):
+        mahalanobis(laplace(2), k=2, **kwargs)
+
+
+def test_cross_k_state_reuse_is_a_clear_error():
+    f2, st = wald(2), None
+    for y in BASE[:50]:
+        _, st = f2(y, st)
+    with pytest.raises(ValueError, match="k=2"):
+        wald(3)(0.5, st)


### PR DESCRIPTION
Two commits, separable:

1. **The study.** Three harnesses and RESULTS.md section 6: contaminated simulation (one RLS learner, only the coordinate system varies), river's learners against river's own StandardScaler/TargetStandardScaler pipeline, and river's own datasets with a body-alone attribution column. Finding: replacing each stream with its (predictive mean, surprise) pair wins 30/30 under every contamination type at a small clean toll; the output sandwich is demoted to a footnote; boundaries (KNN, entity-interleaved streams, informative heavy tails) reported next to the wins. The integration ships separately as [ice-skaters](https://github.com/microprediction/ice-skaters).

2. **Head hardening**, driven by an adversarial input battery: winsorization of huge finite inputs before the body (magnitude-relative, decision-invariant, zero engagements on real data), finiteness guard on custom-base z, constructor validation for min_exc/guard_p/pot_level, and a clear error on cross-k state reuse. Suite goes 23 → 39 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)