### PR TITLE
Outlier benchmarking: resumable TSB-AD-U, FRED v2, detection-delay harnesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ __pycache__/
 dist/
 *.egg-info/
 benchmarks/*.jsonl
+benchmarks/*.log
+benchmarks/data
 benchmarks/data/

--- a/README.md
+++ b/README.md
@@ -55,13 +55,24 @@ homogeneous input every classical detection method assumes and raw data
 never provides. Two measured consequences (protocols and full tables in
 `benchmarks/`):
 
-**Other people's detectors get better in these coordinates.** Same detector,
-same series (UCR anomaly archive, 60 series), only the input changed:
+**Distributional detectors get better in these coordinates — structural
+ones do not.** Same detector, same series (UCR anomaly archive, full 250),
+only the input changed:
 
-| detector | raw series | laplace-transformed | lift |
-|---|---|---|---|
-| DSPOT (EVT thresholding, KDD 2017) | 0.100 | **0.517** | **5.2x** |
-| RRCF (random cut forest, ICML 2016) | 0.250 | **0.450** | **1.8x** |
+| detector | type | raw | laplace-transformed | verdict |
+|---|---|---|---|---|
+| DSPOT (EVT thresholding, KDD 2017) | distributional | 0.120 | **0.232** | improved (5.6x on <10k series) |
+| RRCF (random cut forest, ICML 2016) | weak structural | 0.244 | 0.236 | wash |
+| DAMP (matrix profile, KDD 2022; n=150) | strong structural | **0.587** | 0.427 | hurt |
+
+The gradient is the finding: the transform manufactures the stationarity a
+distributional head assumes, and destroys the recurring templates a
+similarity-search head feeds on — those are the same operation. On
+recurrent (periodic, waveform) series, similarity search owns *where is
+the anomaly* by construction; what it cannot do at any accuracy is *when
+to alarm at a stated false-alarm rate*, which is this stack's actual
+differentiator (see the calibration table above and
+`benchmarks/RESULTS.md` §0 for the full discussion).
 
 **Other people's forecasters get better too.** One-step log-likelihood on 30
 FRED series, exact change of variables through the bijection

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ for y in stream:
 
 That `1e-4` is a **false-alarm rate, not a tuned threshold**: `wald` emits a
 calibrated per-observation p-value, so alarming on `p < alpha` yields a
-false-alarm rate of approximately alpha. Measured, not asserted — on 144
-anomaly-free real-world prefixes (strictly prequential), empirical/nominal:
+false-alarm rate of approximately alpha. On 144 anomaly-free real-world
+prefixes (strictly prequential), empirical/nominal:
 
 | method | 1e-2 | 1e-3 | 1e-4 |
 |---|---|---|---|

--- a/README.md
+++ b/README.md
@@ -55,27 +55,32 @@ homogeneous input every classical detection method assumes and raw data
 never provides. Two measured consequences (protocols and full tables in
 `benchmarks/`):
 
-**Distributional detectors get better in these coordinates — structural
-ones do not.** Same detector, same series (UCR anomaly archive, full 250),
-only the input changed:
+**A prior state-of-the-art detector more than doubles in these
+coordinates.** DSPOT (Siffer et al., KDD 2017 — the streaming extreme-value
+detector that set the calibrated-alarming bar) starves on raw non-stationary
+waveforms and *feasts* on laplace's z: the front-end hands its EVT theorem
+exactly the stationary input it always assumed. Same detector, same series
+(UCR anomaly archive, full 250), only the input changed:
 
 | detector | type | raw | laplace-transformed | verdict |
 |---|---|---|---|---|
-| DSPOT (EVT thresholding, KDD 2017) | distributional | 0.120 | **0.232** | improved (5.6x on <10k series) |
-| RRCF (random cut forest, ICML 2016) | weak structural | 0.244 | 0.236 | wash |
+| **DSPOT** (EVT thresholding, KDD 2017) | distributional | 0.120 | **0.232** | **more than doubles** (5.6x on short series) |
+| RRCF (random cut forest, ICML 2016; AWS Kinesis) | weak structural | 0.244 | 0.236 | wash |
 | DAMP (matrix profile, KDD 2022; n=150) | strong structural | **0.587** | 0.427 | hurt |
 
-The gradient is the finding: the transform manufactures the stationarity a
-distributional head assumes, and destroys the recurring templates a
-similarity-search head feeds on — those are the same operation. On
-recurrent (periodic, waveform) series, similarity search owns *where is
+The gradient is the finding: the transform helps a detector *exactly to the
+degree it is distributional rather than structural*. It manufactures the
+stationarity a distributional head assumes, and destroys the recurring
+templates a similarity-search head feeds on — those are the same operation.
+On recurrent (periodic, waveform) series, similarity search owns *where is
 the anomaly* by construction; what it cannot do at any accuracy is *when
 to alarm at a stated false-alarm rate*, which is this stack's actual
 differentiator (see the calibration table above and
 `benchmarks/RESULTS.md` §0 for the full discussion).
 
-**Other people's forecasters get better too.** One-step log-likelihood on 30
-FRED series, exact change of variables through the bijection
+**And every classical forecaster gets ~2 nats better.** The same transform
+lifts the forecasting workhorses too — one-step log-likelihood on 30 FRED
+series, exact change of variables through the bijection
 `z_t = Phi^-1(F_t(y_t))`:
 
 | opponent | lift (nats/point) | wins |
@@ -87,7 +92,10 @@ FRED series, exact change of variables through the bijection
 
 Fronted opponents converge to the skaters forecaster plus a few hundredths
 of a nat: the body had already extracted nearly everything they know how to
-model.
+model. So the one transform that makes laplace a calibrated forecaster also
+makes prior-SOTA distributional detectors and every classical forecaster
+better — because in its coordinates each method finally sees the stationary,
+calibrated stream its theorem assumes.
 
 ## The machines
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -77,12 +77,15 @@ De-anchoring UCR shows matrix profile's edge is genuine recurrence
 capability (it survives de-anchoring slower than its window) and collapses
 only when the level moves WITHIN a window — precisely where its per-window
 z-normalization, its Achilles heel, breaks. That failure mode is
-repairable: replacing znorm with laplace's causal normalization
-(DAMP-laplace) reverses the collapse (16-4 paired under fast de-anchoring)
-at a real cost on stationary data (13-6 the other way). So the front-end
-does not merely help distributional heads and hurt structural ones — it
-can also fix a structural head's normalizer, but only in the non-stationary
-regime that normalizer cannot handle.
+repairable in a narrow regime: replacing znorm with laplace's causal
+normalization (DAMP-laplace) reverses the collapse (16-4 paired) under
+*fast* within-window de-anchoring, at a real cost on stationary data (13-6
+the other way). But the repair does NOT transfer to real martingale series
+(FRED levels, §3b): those carry a unit root yet drift too slowly relative to
+the window for znorm to fail, so damp_raw wins there decisively. So the
+front-end can fix a structural head's normalizer, but only when the level
+moves fast relative to the subsequence window — a real effect with a small
+deployment footprint, not a general "laplace fixes SOTA" claim.
 
 ## 1. Detector front-end — FINAL (UCR-60, argmax protocol)
 
@@ -256,7 +259,41 @@ per-window znorm cannot absorb — at a real cost on stationary data. Swap it
 in when the level moves within a window; keep znorm when it does not.** The
 non-circular deployment test is `damp_lap` vs `damp_raw` on genuinely
 martingale series (FRED), where there is no stationary template to fall back
-on and laplace-z is MP's only viable normalization — next.
+on and laplace-z is MP's only viable normalization.
+
+### The FRED arm — the crossover does NOT transfer (`martingale_fred.py`, n=96)
+
+Planted spike/burst/shift on FRED series, argmax hit and rank percentile,
+window M=100. Run both on the unit-root levels (the genuine martingale
+regime) and, as a control, on the differenced returns (stationary):
+
+| mode | detector | hit | pct | lap vs raw (paired) |
+|---|---|---|---|---|
+| **levels** (unit root) | damp_raw | **0.438** | **0.962** | — |
+| | damp_lap | 0.271 | 0.926 | pct lap>raw 27/96; hit lap-only 14, raw-only 30 |
+| changes (stationary) | damp_raw | 0.146 | 0.956 | — |
+| | damp_lap | 0.156 | 0.911 | pct lap>raw 40/96; hit ~tied (10 vs 9) |
+
+**The `rw_fast` crossover does not reproduce on real martingale data.** On
+FRED levels `damp_raw` wins decisively (paired hit 30-14); on returns the two
+are a wash. Two reasons, and they tighten the claim rather than refute it:
+(1) FRED price levels carry a unit root but drift *slowly relative to a
+100-point window* — rates and indices barely move over M=100 next to an
+8-sigma planted spike — so per-window znorm copes and laplace-z buys nothing;
+FRED levels behave like `rw_slow` (a wash), not `rw_fast`. (2) A spike on a
+*level* is a large-amplitude transient, an easy discord znorm catches cleanly,
+whereas UCR-cumsum's anomaly was a subtle pre-existing waveform defect that
+integration smeared into a hard step. Different anomaly character, opposite
+winner.
+
+**Honest conclusion:** DAMP-laplace is a real but NARROW repair. It helps only
+when the level moves fast relative to the subsequence window — a regime the
+`rw_fast` injection manufactures but ordinary financial levels at M=100 do not
+exhibit. The controlled crossover above (16-4) is genuine; its deployment
+footprint is small. The earlier "laplace fixes SOTA under our challenge"
+framing was too broad and is narrowed to this scope. The mechanism predicts
+the edge would return at a smaller window M, or on genuinely fast-drifting
+levels (intraday volatility, FX) — an open probe, not a claim.
 
 ## 4. The calibration panel — the differentiator, measured
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -103,6 +103,20 @@ memory never managed (and 0.675 on the 40 shortest). The zbank sigma-grid
 tuning. All three tapes were run under skaters 0.12.x (gaussian z tails);
 the 0.13.0 GPD-tails default re-run is checkpointing in this directory.
 
+### The 0.13.0 re-run (GPD tails default, 2026-07-21) — a real regression
+
+Same harness, same slow-memory config, same warmup protocol, full 250,
+skaters 0.13.0: mahS 0.288 < |z1| 0.280 ~ mah 0.256, zU 0.232, trivial
+0.216 — every channel drops vs the 0.12.x tapes (mahS 0.304, z1 0.288,
+mah 0.280, zU 0.276). The mechanism is the design tension stated plainly:
+the tail splice exists to make extreme z CALIBRATED, which necessarily
+compresses the very tail contrast argmax ranking feeds on; zU, built
+entirely from extreme per-margin p-values, bleeds most (-4.4 points).
+Calibration and ranking are different objectives and now measurably trade
+off — quote UCR rows with the tails config attached, and consider
+`tails="gaussian"` (the old behavior, still available) when the task is
+argmax localization rather than alarming.
+
 Findings the study produced regardless of scores: a horizon-misalignment bug
 in skaters' search() (third instance of the pattern; fixed, parity green);
 the effective-rank collapse of the z scatter -> empirical null + factor
@@ -145,6 +159,69 @@ noise. Diagnosis: real backgrounds contain genuine unlabeled anomalies
 confounded measure. v2: score the planted window's rank percentile in the
 full score ordering (robust to dominant natural events), and/or mask known
 crisis windows. Keep argmax row for reference.
+
+### v2 — rank percentile with crisis masking (n=120, 2026-07-21)
+
+`fred_anomaly_v2.py`, same deterministic injections, skaters 0.13.0.
+Masking GFC/COVID from the ranking set lifts every method's argmax hit
+rate (z1 0.250 -> 0.317, mz 0.250 -> 0.342), confirming the v1 confound
+was real. Mean rank percentile (masked / argmax-hit masked):
+
+| method | pct_m | hit_m | note |
+|---|---|---|---|
+| dspot_z | **0.9951** | 0.275 | fronted DSPOT best percentile again |
+| z1 | 0.9945 | 0.317 | best own channel |
+| rrcf_raw | 0.9921 | 0.283 | |
+| mah | 0.9912 | 0.175 | percentile fine, argmax poor |
+| dspot_raw | 0.9886 | 0.325 | |
+| mz | 0.9850 | **0.342** | trivial baseline wins argmax-hit |
+| mahS64 | 0.9126 | 0.233 | scan window dilutes rank sharply |
+
+Read: on percentile the field is compressed (everyone ~0.98-0.995) and the
+front-end story repeats (dspot_z > dspot_raw on percentile); on masked
+argmax the trivial mz is top — planted 8-sigma spikes on economic series
+are simply not hard, so this benchmark measures the easy regime. The
+discriminating FRED evidence stays the calibration panel and the delay
+panel, not injections.
+
+### Detection delay at fixed alarm budget (n=83 burst+shift, 2026-07-21)
+
+`detection_delay.py`. In the stated-alpha regime (deployable, no oracle):
+z1 at alpha=1e-3 detects 63% at median delay 12 ticks with realized 1.43
+false alarms per 1k (1.4x nominal — the 0.13.0 tails keeping their
+budget); mah detects 80% but at delay 157 and 2.8x budget. In the
+matched-quantile regime mz is the delay/detection sweet spot (0.81
+detect, delay 18, 2.4/1k at the 1e-3 budget); dspot's saturated score
+defeats quantile matching (30-40 fa/1k regardless of budget) — its native
+alarm channel is required before its delay row is quotable.
+
+## 5b. TSB-AD-U — the leaderboard run (tuning read 2026-07-21)
+
+Two-phase harness (`tsb_ad_run.py` scores, `tsb_ad_eval.py` official
+metrics). Tuning split (48 series), mean VUS-PR: slow-memory config
+z1 **0.190** > zU 0.188 > mz 0.177 > mahS8 0.169 > mah 0.159 > mahS64
+0.138; the default-memory config is worse everywhere (best 0.173). Config
+frozen for eval: slow memory, z1 the headline channel — note the
+UCR-consistent pattern that the plain parade surprise beats the
+Mahalanobis geometry on ranking metrics, and the trivial EWMA z sits only
+0.013 VUS-PR behind the best own channel on this split. Leaderboard
+context: univariate top is Sub-PCA 0.42. (The metrics pass first died on
+a single inf tick — the mz baseline's denormal-variance overflow, since
+clamped at source and sanitized at eval; not a skaters defect.)
+
+### Eval split — FINAL (350 series, 2026-07-21)
+
+Mean VUS-PR: mahS8 0.162 ~ zU 0.161 ~ **mz 0.160** ~ z1 0.153 ~ mahS64
+0.152 ~ mah 0.150. The tuning-split ordering did NOT generalize (z1 led
+tuning at 0.190, trails the trivial baseline on eval), and the whole own
+stack is statistically on top of the EWMA z-score at ~0.16 — a third of
+the leaderboard top (Sub-PCA 0.42, KShapeAD 0.40), squarely in the
+trivial band. Same verdict as UCR, now on the leaderboard benchmark: the
+laplace body cannot represent the short waveform periods that dominate
+these archives, so ranking-metric benchmarks score its weakest organ.
+The differentiator remains calibration (panel, §4) and stated-alpha delay
+(§5) — capabilities VUS-PR is blind to by construction. Quote this row
+plainly as the credibility line; do not spin it.
 
 ## 6. Regression front-end — contaminated simulation (240 runs)
 
@@ -618,33 +695,23 @@ null approximately holds) and, for a paper, local power theory.
 
 ## 8. Still to come
 
-- FRED v2 with rank-percentile scoring — HARNESS READY (2026-07-20):
-  `fred_anomaly_v2.py`, same deterministic injections as v1, scores the
-  planted window's rank percentile with and without GFC/COVID masking;
-  resumable per series. Smoke-tested; full 150-series run queued in
-  `run_outlier_fleet.sh`.
-- Detection delay at fixed alpha — HARNESS READY (2026-07-20):
-  `detection_delay.py`, burst+shift injections, stated-alpha regime for
-  p-value methods vs matched-empirical-quantile regime for score-only
-  methods, pre-onset false alarms per 1k ticks reported alongside.
-  Caveat found at smoke test: quantile-thresholding DSPOT's saturated
-  score inflates its realized false-alarm rate — its native alarm channel
-  should be added before quoting its delay row.
-- TSB-AD-U leaderboard run (VUS-PR; top is 0.42, simple methods lead) —
-  HARNESS READY (2026-07-20), two phases, both resumable: `tsb_ad_run.py`
-  caches per-tick score arrays per series (detection venv, skaters
-  0.13.0); `tsb_ad_eval.py` computes the official VUS/AUC bundle with the
-  TSB-AD package in `.venv-tsb` (it pins numpy<2 — keep venvs separate).
-  mahS windows are derived at eval time from the cached mah array.
-  Tuning-split scorer started 2026-07-20 (2 nice'd workers).
+Overnight fleet 2026-07-20/21 (11 workers, nice 19, 13h) closed out: FRED
+v2 rank-percentile (§5, n=120), detection delay (§5, n=83), TSB-AD-U
+tuning read (§5b), UCR full-250 under 0.13.0 tails (§3 — a real
+argmax regression, documented). Remaining:
+
+- TSB-AD-U eval-split metrics pass (scores cached; VUS bundle running
+  after the inf-sanitizer fix) — the leaderboard row.
+- DSPOT native alarm channel in `detection_delay.py` (quantile matching
+  is defeated by its saturated score; its delay row is not yet quotable).
 - GPD/EVT tail for the detector's extreme p-values (steal DSPOT's tail
   theorem for our head); unclamped -logpdf surprise channel (the z-clamp
   saturates at |z|=7.03, erasing 20-sigma vs 100-sigma distinctions).
   Note: skaters 0.13.0 ships GPD tails default-on in the forecaster, so
   the z stream's own p-values are now calibrated at source; the mah
-  (Mahalanobis-layer) overcalibration remains its own open defect.
-- UCR full-250 re-run under skaters 0.13.0 tails (the three 0.12.x tapes
-  above are FINAL for the old default; re-run seeded in this directory).
+  (Mahalanobis-layer) overcalibration remains its own open defect — and
+  §3's 0.13.0 regression shows calibration and argmax ranking now
+  measurably trade off, so the repair must be scored on both axes.
 - Regression front-end v2: slow-memory body for the zout/spikes_y cell;
   target-intercept shift scenario; per-entity bodies (the ChickWeights
   fix); k=3 multi-horizon surprise features for the drift/shift rows;

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -367,6 +367,46 @@ mah overconfidence. Plain z1 on the default (gpd) holds ~2x nominal at 1e-3
 on the same data — so the extra overshoot is the Mahalanobis empirical-null
 layer itself, not an upstream z-stream artifact. The mah repair (§8) stands.
 
+### 4c. Diagnosing and repairing mah (`mah_diagnostic.py`, `mah_repair_sweep.py`)
+
+**Decomposition** (knobs isolate the p-value stages; n=96 non-price FRED,
+median per-series FPR / nominal):
+
+| config | x@1e-2 | x@1e-3 | x@1e-4 | what it isolates |
+|---|---|---|---|---|
+| z1 (plain parade) | 1.2 | 2.2 | 7.4 | the floor (base rate + clamp) |
+| bulk (chi2 only, `min_exc=1e9`) | 2.6 | **10.6** | **62.9** | Satterthwaite null alone |
+| full (default: factor, GPD+nlp) | 2.1 | 4.2 | 18.6 | shipped |
+| shrink (`scatter="shrink"`) | 1.7 | 3.3 | 12.4 | scatter model |
+
+The overconfidence is the **bulk Satterthwaite chi2 null**, not the tail
+machinery: turning the GPD/nlp off (`bulk`) runs 10.6x/62.9x, and the GPD
+*repairs* most of it (full 4.2x/18.6x). Mechanism: `d2 = v' Sigma^-1 v` with
+`Sigma` EWMA-estimated (effective n ~ 2/alpha ~ 99) is the finite-sample
+Hotelling regime — `d2` follows a heavy scaled-F, not chi2 — and a two-moment
+match keeps a chi2 tail shape that is fundamentally too thin. The factor
+scatter also inflates `d2` vs plain shrinkage (full 4.2x vs shrink 3.3x).
+
+**Dual-axis repair sweep** (argmax ranking AND clean-region FPR on the same
+injected FRED series, n=96; existing knobs only):
+
+| config | argmax | x@1e-2 | x@1e-3 | x@1e-4 |
+|---|---|---|---|---|
+| base (pot 0.98, factor) | 0.156 | 1.9 | 2.5 | 5.4 |
+| pot95 | 0.146 | 1.5 | 1.8 | 2.9 |
+| pot90 | 0.146 | 1.3 | 1.8 | 3.0 |
+| shrink | 0.167 | 1.5 | 2.2 | 3.6 |
+| **pot95_shrink** | **0.177** | **1.2** | **1.4** | **2.7** |
+
+The argmax column is flat within binomial noise (+/-~3.6 series on n=96), so no
+config trades ranking for calibration on this set — confirming that lowering
+`pot_level` is ranking-invariant by construction (the p-value is monotone in
+`d2` regardless of the threshold). `pot95_shrink` calibrates best on all three
+depths, near the z1 floor. Caveat: FRED injection is the *easy* ranking regime
+(the confounded-argmax problem, §5), so the genuine ranking test for the
+`shrink` component is UCR waveforms — pending before any default change.
+`pot_level` is safe to lower now; `shrink` is gated on the UCR check.
+
 ## 5. FRED injection (argmax) — protocol needs v2
 
 `fred_anomaly.py`, n=100 real FRED change series, planted spike/burst/shift.

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -321,6 +321,52 @@ the excess tails run ~0.7) brought it to ~5x; and the z-clamp saturation
 unbounded -logpdf channel with its own POT tail, restoring evidence at any
 depth (2e-11 where the clamp capped at 3e-5) at a small bulk cost.
 
+### 4b. Does the lattice projection pollute the z tail? (`sticky_ablation.py`)
+
+Conjecture: laplace's `sticky` lattice projection (on by default) adds
+near-Dirac atoms at revisited values; on lattice series (administrative
+rates whose CHANGE series is a run of exact zeros) an atom is a step in the
+predictive CDF, so a normal point near the atom is mapped through a
+near-vertical F_t and picks up a spurious large |z| — polluting the z tail
+and inflating alarms. Tested: laplace `sticky {on,off}` x `tails {gpd,
+gaussian}`, 120 non-price FRED series, paired per series (same real events
+both ways), split by exact-repeat fraction. Median per-series two-sided FPR
+of erfc(|z1|); the 1-step LL is the forecasting cost of turning sticky off.
+
+| group | config | LL | FPR@1e-2 | @1e-3 | @1e-4 |
+|---|---|---|---|---|---|
+| continuous (n=48, control) | sticky, gpd | 3.4303 | 1.19e-2 | 2.14e-3 | 7.35e-4 |
+| | no-sticky, gpd | 3.4304 | 1.19e-2 | 2.14e-3 | 7.35e-4 |
+| lattice (n=72) | sticky, gpd (default) | **3.35** | 1.19e-2 | 2.41e-3 | 7.43e-4 |
+| | no-sticky, gpd | 2.52 | 1.19e-2 | 2.37e-3 | 7.43e-4 |
+| | sticky, gaussian | 3.30 | 2.43e-2 | 9.28e-3 | 4.64e-3 |
+| | no-sticky, gaussian | 2.51 | 2.02e-2 | 8.27e-3 | 4.28e-3 |
+
+Three reads, one of which corrects an earlier claim:
+
+1. **Falsifiable control passes exactly.** On continuous series sticky is
+   identical on/off (LL 3.4303 vs 3.4304; every FPR equal) — atoms never
+   fire, the wrapper vanishes, confirming atoms are the mechanism.
+2. **The raw artifact is real but modest, and the DEFAULT splice absorbs it.**
+   With gaussian tails (no splice) sticky inflates lattice-series FPR ~10-20%
+   (9.28e-3 vs 8.27e-3 at 1e-3) — the predicted pollution. But with the
+   default `tails="gpd"` sticky and no-sticky are essentially identical
+   (2.41e-3 vs 2.37e-3; paired-worse 34/72, a coin flip). Earlier note that
+   "the GPD splice cannot reach the shoulder" was WRONG: nominal 1e-2..1e-4
+   are |z| beyond 2.6 sigma, i.e. inside the GPD-governed region (thresholds
+   at the 98% quantile), and the censored-ML re-fit on actual exceedances
+   absorbs the atom-induced distortion.
+3. **sticky is a large forecasting win on lattice series** (+0.83 nats) at no
+   calibration cost on the default. Keep it on; this is a clean validation
+   that the 0.13.0 tail splice does its job (it repairs sticky's distortion
+   as a side effect).
+
+Consequence for the mah repair: this rules OUT sticky as the source of the
+mah overconfidence. Plain z1 on the default (gpd) holds ~2x nominal at 1e-3
+(consistent with the genuine-anomaly base rate in FRED), while mah runs ~9x
+on the same data — so the extra overshoot is the Mahalanobis empirical-null
+layer itself, not an upstream z-stream artifact. The mah repair (§8) stands.
+
 ## 5. FRED injection (argmax) — protocol needs v2
 
 `fred_anomaly.py`, n=100 real FRED change series, planted spike/burst/shift.

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -10,7 +10,66 @@ Working results for the anomaly/front-end study (issues #88, PR branch
 
 All runs: strictly causal scores (no whole-series normalisation), defaults
 unless stated, one pass. Protocols in `RESEARCH.md`; harnesses in this
-directory. Updated 2026-07-07.
+directory. Updated 2026-07-21.
+
+## 0. Discussion — the synthesis, stated up front
+
+Every result below sorts under two distinctions. Read the tables through
+them.
+
+**Two jobs.** Job 1 is localization: *where* is the anomaly (argmax, VUS,
+rank percentile — ranking metrics, blind to calibration by construction).
+Job 2 is alarming: *when* to fire at a stated false-alarm budget (the
+calibration panel, detection delay at stated alpha). Methods that emit
+scores can only do job 2 with an oracle threshold; methods that emit
+calibrated p-values do it as shipped. Our stack's differentiator is job 2,
+and only job 2.
+
+**Two regimes.** On *recurrent* series (UCR's periodic physiology, most of
+TSB-AD-U), normal behavior traces a low-dimensional manifold in
+delay-embedding space and an anomaly is a subsequence far from every
+historical neighbor. Similarity search reads that off directly and owns
+job 1 by construction: raw DAMP 0.587 on UCR-150 vs our best-ever 0.304;
+our TSB-AD-U eval row (~0.16 VUS-PR, the trivial band, vs leaderboard top
+0.42) is the same verdict on the leaderboard benchmark. On
+*non-recurrent* series (FRED: drift, regime shifts, fat tails, no
+periodicity) there is no template and no meaningful
+nearest-neighbor null — every neighborhood of the trace is sparse — so
+the only coherent notion of anomaly is "surprising under a calibrated
+predictive density," which forces a forecaster + EVT tail. That is where
+the panel and delay results live. Caveat stated plainly: we never ran
+DAMP on FRED; the non-recurrent half of this claim rests on the mechanism
+plus RRCF's indifference there, not on a direct measurement. And the FRED
+*injection* benchmarks (v1 and v2) turned out to discriminate nobody —
+planted 8-sigma spikes are the easy regime for every method (§5).
+
+**The front-end verdict is a gradient, not a blanket.** Same detector,
+same series, only the input changes (raw y vs parade z; full-250 UCR
+unless noted):
+
+| head | type | raw -> fronted | verdict |
+|---|---|---|---|
+| DSPOT | distributional (EVT tail, assumes stationarity) | 0.120 -> **0.232** (5.6x on <10k) | improved, everywhere measured — also best FRED-v2 percentile (0.9951) and deep-tail rates toward nominal on both FRED and UCR |
+| RRCF | weak structural (shingles) | 0.244 -> 0.236 | wash — gains drift/scale families, loses periodic-template families |
+| DAMP | strong structural (left-discord matrix profile, n=150) | 0.587 -> 0.427 | **hurt** — z whitens exactly the recurrence it feeds on, and it carries its own local normalizer |
+
+The rule: the front-end improves a head to the exact degree the head is
+distributional (stationarity-hungry) and degrades it to the degree it
+feeds on repeated templates. The Rosenblatt z manufactures stationarity
+and destroys recurrence — those are the same operation.
+
+**One-sentence scope statement.** Pattern matching owns "where" on
+recurrent series; calibrated surprise owns "when to alarm" everywhere;
+the front-end improves any head exactly to the degree that head is
+distributional rather than structural.
+
+Two standing caveats on the waveform side: similarity search "solves"
+recurrent series at the ranking level only (at nominal 1e-3 every method,
+DAMP included, drowns in false alarms on the periodic families), and
+matrix-profile methods need the period to fit their window. And one on
+ours: skaters 0.13.0's calibrated tails cost argmax contrast (§3) —
+calibration and localization now measurably trade off even within our own
+stack.
 
 ## 1. Detector front-end — FINAL (UCR-60, argmax protocol)
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -399,13 +399,38 @@ injected FRED series, n=96; existing knobs only):
 | **pot95_shrink** | **0.177** | **1.2** | **1.4** | **2.7** |
 
 The argmax column is flat within binomial noise (+/-~3.6 series on n=96), so no
-config trades ranking for calibration on this set — confirming that lowering
-`pot_level` is ranking-invariant by construction (the p-value is monotone in
-`d2` regardless of the threshold). `pot95_shrink` calibrates best on all three
-depths, near the z1 floor. Caveat: FRED injection is the *easy* ranking regime
-(the confounded-argmax problem, §5), so the genuine ranking test for the
-`shrink` component is UCR waveforms — pending before any default change.
-`pot_level` is safe to lower now; `shrink` is gated on the UCR check.
+config trades ranking for calibration on this set. `pot95_shrink` calibrates
+best on all three depths, near the z1 floor.
+
+**UCR ranking gate** (`mah_ucr_ranking.py`, argmax accuracy, n=40 shortest):
+base 20/40 = 0.500, shrink 18/40 = 0.450, pot95_shrink 22/40 = 0.550 — all
+within binomial noise (+/-~3.2). Two corrections came out of it:
+
+* **`pot_level` is NOT ranking-invariant.** shrink (18) != pot95_shrink (22)
+  proves it. The GPD splice *raises* p in the tail, so `-log10 p` has a
+  downward discontinuity at `t_pot`: a sub-maximal-d2 tick just below the
+  threshold can outrank the true max just above it, and moving `pot_level`
+  moves that discontinuity. The earlier "monotone, invariant" claim was wrong.
+* **Lowering `pot_level` fails masking resistance.** The `pot_level=0.95`
+  default change (attempted, reverted) breaks `tests/test_heads.py::
+  test_masking_resistance`: with a 120-sigma spike every 40 ticks, only 10/13
+  fire at p<1e-3 (vs 13/13 at 0.98; worst outlier p 1.9e-3 vs 2.1e-11). The
+  dense spikes contaminate the lower exceedance set and corrupt the GPD fit
+  for extreme excesses. Sparse-anomaly FRED/UCR benchmarks could not surface
+  this — the test suite did.
+
+**Conclusion.** `pot_level=0.95` is a genuine calibration win on sparse-anomaly
+data but trades away masking resistance under dense outliers, so it is NOT a
+safe default; reverted, 0.98 kept, finding documented in the docstring. The
+right repair is a tail *shape* fix that keeps the 98% threshold: replace the
+bulk null's scaled-chi2 with a **scaled-F carrying the estimation dof**
+(`d2 ~ [k(n_eff-1)/(n_eff-k)] F(k, n_eff-k)`, `n_eff ~ 2/alpha`), which models
+the heavy finite-sample tail at its source instead of asking the empirical GPD
+to mop it up from a lower threshold. That is a localized change to the null
+family (both languages, with the masking test as a gate) — the next step, not
+rushed. `scatter="shrink"` remains a documented opt-in (best combined
+calibration, no measured ranking cost) but not the default (the factor model
+serves the multivariate `zbank`).
 
 ## 5. FRED injection (argmax) — protocol needs v2
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -92,12 +92,16 @@ waveform periods (~50-400 samples) the Laplace body cannot represent (its
 seasonal grid is calendar {7,12,24}), so every cycle reads as fresh surprise.
 That is a *body* weakness observed through the head — filed upstream as
 skaters#91 — and matrix-profile methods own that terrain by construction.
-Slow-memory config (sa 0.01/da 0.005), full archive (n=247 of 250; the run
-was stopped three 300k-point series short): mahS 0.308 > |z1| 0.291 > mah
-0.283 > trivial 0.219. Slow memory is worth ~+3 points over default and
-flips the ordering — the multivariate scan beats the per-horizon rule at
-scale, which default memory never managed (and 0.675 on the 40 shortest).
-The zbank sigma-grid sits between the configs without tuning.
+Slow-memory config (sa 0.01/da 0.005), full archive (FINAL, all 250; the
+detached run completed 2026-07-13): mahS 0.304 > |z1| 0.288 > mah 0.280 >
+zU 0.276 > trivial 0.216. By length, mahS: 32/53 (<10k), 32/97 (10-50k),
+12/100 (>=50k). Slow memory is worth ~+3-6 points over default (default-250
+FINAL: |z1| 0.276 > zU 0.264 > mah = mahS 0.240) and flips the ordering —
+the multivariate scan beats the per-horizon rule at scale, which default
+memory never managed (and 0.675 on the 40 shortest). The zbank sigma-grid
+(FINAL, n=60: |z1| 0.550, mahS 0.533) sits between the configs without
+tuning. All three tapes were run under skaters 0.12.x (gaussian z tails);
+the 0.13.0 GPD-tails default re-run is checkpointing in this directory.
 
 Findings the study produced regardless of scores: a horizon-misalignment bug
 in skaters' search() (third instance of the pattern; fixed, parity green);
@@ -614,15 +618,33 @@ null approximately holds) and, for a paper, local power theory.
 
 ## 8. Still to come
 
-- slow-alpha full-250 (running); zbank-60 and default-250 (running,
-  detached).
-- FRED v2 with rank-percentile scoring.
-- Detection delay at fixed alpha (the panel covers FPR; delay is the
-  other axis of the Wald tradeoff).
+- FRED v2 with rank-percentile scoring — HARNESS READY (2026-07-20):
+  `fred_anomaly_v2.py`, same deterministic injections as v1, scores the
+  planted window's rank percentile with and without GFC/COVID masking;
+  resumable per series. Smoke-tested; full 150-series run queued in
+  `run_outlier_fleet.sh`.
+- Detection delay at fixed alpha — HARNESS READY (2026-07-20):
+  `detection_delay.py`, burst+shift injections, stated-alpha regime for
+  p-value methods vs matched-empirical-quantile regime for score-only
+  methods, pre-onset false alarms per 1k ticks reported alongside.
+  Caveat found at smoke test: quantile-thresholding DSPOT's saturated
+  score inflates its realized false-alarm rate — its native alarm channel
+  should be added before quoting its delay row.
+- TSB-AD-U leaderboard run (VUS-PR; top is 0.42, simple methods lead) —
+  HARNESS READY (2026-07-20), two phases, both resumable: `tsb_ad_run.py`
+  caches per-tick score arrays per series (detection venv, skaters
+  0.13.0); `tsb_ad_eval.py` computes the official VUS/AUC bundle with the
+  TSB-AD package in `.venv-tsb` (it pins numpy<2 — keep venvs separate).
+  mahS windows are derived at eval time from the cached mah array.
+  Tuning-split scorer started 2026-07-20 (2 nice'd workers).
 - GPD/EVT tail for the detector's extreme p-values (steal DSPOT's tail
   theorem for our head); unclamped -logpdf surprise channel (the z-clamp
   saturates at |z|=7.03, erasing 20-sigma vs 100-sigma distinctions).
-- TSB-AD-U leaderboard run (VUS-PR; top is 0.42, simple methods lead).
+  Note: skaters 0.13.0 ships GPD tails default-on in the forecaster, so
+  the z stream's own p-values are now calibrated at source; the mah
+  (Mahalanobis-layer) overcalibration remains its own open defect.
+- UCR full-250 re-run under skaters 0.13.0 tails (the three 0.12.x tapes
+  above are FINAL for the old default; re-run seeded in this directory).
 - Regression front-end v2: slow-memory body for the zout/spikes_y cell;
   target-intercept shift scenario; per-entity bodies (the ChickWeights
   fix); k=3 multi-horizon surprise features for the drift/shift rows;
@@ -645,6 +667,17 @@ python benchmarks/river_frontend.py --seeds 30 --workers 6   # pip install river
 python benchmarks/river_data_frontend.py --workers 6
 python benchmarks/ablation_frontend.py --seeds 30 --workers 6
 python benchmarks/ablation_river.py --workers 6   # pip install ice-skaters
+
+# outlier fleet (all resumable; WORKERS=2 default is deliberately gentle)
+WORKERS=2 ./benchmarks/run_outlier_fleet.sh > fleet.log 2>&1 &
+python benchmarks/tsb_ad_run.py --split tuning --workers 2   # phase 1
+.venv-tsb/bin/python benchmarks/tsb_ad_eval.py --split tuning  # phase 2
+python benchmarks/fred_anomaly_v2.py --limit 150 --workers 2
+python benchmarks/detection_delay.py --limit 150 --workers 2
 ```
 UCR data: see RESEARCH.md (download + extract into `data/UCR_Anomaly_FullData`).
 FRED data: cached under `benchmarks/data/` (see `benchmarks/fred.py`).
+TSB-AD-U data: `benchmarks/data/TSB-AD-U/` (zip URL in RESEARCH.md; split
+lists auto-fetched). On this machine `benchmarks/data` is a symlink into the
+skaters repo's shared cache. Envs: `.venv` (detection, skaters 0.13.0
+editable) and `.venv-tsb` (TSB-AD metrics only; numpy<2, do not mix).

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -71,6 +71,19 @@ ours: skaters 0.13.0's calibrated tails cost argmax contrast (§3) —
 calibration and localization now measurably trade off even within our own
 stack.
 
+**The anchor refinement (§3b).** "Recurrent vs non-recurrent" is more
+precisely "is the level-anchor intact at the subsequence timescale."
+De-anchoring UCR shows matrix profile's edge is genuine recurrence
+capability (it survives de-anchoring slower than its window) and collapses
+only when the level moves WITHIN a window — precisely where its per-window
+z-normalization, its Achilles heel, breaks. That failure mode is
+repairable: replacing znorm with laplace's causal normalization
+(DAMP-laplace) reverses the collapse (16-4 paired under fast de-anchoring)
+at a real cost on stationary data (13-6 the other way). So the front-end
+does not merely help distributional heads and hurt structural ones — it
+can also fix a structural head's normalizer, but only in the non-stationary
+regime that normalizer cannot handle.
+
 ## 1. Detector front-end — FINAL (UCR-60, argmax protocol)
 
 Same detector, same series; only the input changes (raw y vs parade z from
@@ -182,6 +195,68 @@ the effective-rank collapse of the z scatter -> empirical null + factor
 scatter with exact Woodbury; masking through the null's second moment ->
 winsorised updates; the sigma-memory axis; and (from the hardening suite)
 skaters' state-purity fix enabling checkpoint/restore (0.12.1).
+
+## 3b. Anchor vs recurrence, and DAMP-laplace (`martingale_transform_study.py`)
+
+Is matrix profile's UCR dominance an *absolute-anchor* artifact (biological
+series are level-stationary; finance is a martingale with a unit root) or a
+genuine *recurrence* capability? We de-anchor each series and re-run every
+detector. `window_wander` = the sigma-fraction the injected level drifts over
+one subsequence window M=100; anomaly LOCATION is preserved by every
+transform (cumsum changes the anomaly TYPE, spike->step, not tracked here).
+UCR n=60 shortest (family-heavy: AirTemperature, InternalBleeding, Walking,
+insectEPG — read as directional), argmax accuracy:
+
+| detector | raw | rw_slow (ww 0.15) | rw_fast (ww 3.0) | cumsum |
+|---|---|---|---|---|
+| mah | 0.417 | 0.283 | 0.167 | 0.200 |
+| mahS | 0.483 | 0.333 | 0.167 | 0.150 |
+| z1 | 0.500 | 0.467 | 0.250 | 0.200 |
+| damp_raw (znorm MP, SOTA) | **0.617** | **0.567** | 0.133 | 0.433 |
+| damp_rawnn (no normalizer) | 0.667 | 0.533 | 0.033 | 0.117 |
+| damp_z (znorm on laplace-z) | 0.383 | 0.450 | 0.083 | 0.283 |
+| **damp_lap (non-norm MP on laplace-z)** | 0.500 | 0.517 | **0.333** | 0.367 |
+
+**Q1 — the anchor bites at WINDOW scale, not globally.** `damp_raw` barely
+moves under a random walk slower than a window (0.617 -> 0.567) and survives
+integration (0.433); it collapses only when the level moves ~3 sigma WITHIN a
+window (rw_fast 0.133) — precisely znorm's blind spot. Matrix profile's edge
+is genuine recurrence capability, robust to global de-anchoring; it is not an
+absolute-anchor artifact. The `damp_rawnn` control confirms the mechanism:
+strip the normalizer and rw_fast annihilates it (0.033).
+
+**Q2 — our head degrades more gracefully but does not overtake.** `z1` is
+flat across raw/rw_slow (0.500/0.467) and beats `damp_raw` under rw_fast
+(0.250 vs 0.133); it does not catch up and win on stationary turf.
+
+**Q3 — DAMP-laplace is a TARGETED repair, not a free lunch.** Swapping
+laplace's causal model-based normalization in for the per-window znorm
+(non-normalized MP on the laplace-z stream) is the user's proposal. Paired,
+per series, `damp_lap` vs `damp_raw`:
+
+| transform | lap beats raw | raw beats lap | both | neither |
+|---|---|---|---|---|
+| raw | 6 | **13** | 24 | 17 |
+| rw_slow | 9 | 12 | 22 | 17 |
+| rw_fast | **16** | 4 | 4 | 36 |
+| cumsum | 16 | 20 | 6 | 18 |
+
+On stationary data znorm is the right normalizer and `damp_lap` genuinely
+loses (13-6) — laplace-z discards the template, exactly the §1 mechanism. But
+under within-window de-anchoring the reversal is strong and real (16-4, not
+an aggregation artifact): where the level moves inside a window and znorm
+breaks, laplace's normalization is decisively better. Global de-anchoring and
+integration are washes. The win concentrates in the lower-frequency,
+drift-prone families (InternalBleeding 9-3 of 28, CIMIS AirTemperature 8-4 of
+13); high-frequency insectEPG is 0-0 (nobody localizes under rw_fast).
+
+The precise claim: **laplace-normalization repairs matrix profile for exactly
+one failure mode — non-stationarity at the subsequence timescale that
+per-window znorm cannot absorb — at a real cost on stationary data. Swap it
+in when the level moves within a window; keep znorm when it does not.** The
+non-circular deployment test is `damp_lap` vs `damp_raw` on genuinely
+martingale series (FRED), where there is no stationary template to fall back
+on and laplace-z is MP's only viable normalization — next.
 
 ## 4. The calibration panel — the differentiator, measured
 

--- a/benchmarks/detection_delay.py
+++ b/benchmarks/detection_delay.py
@@ -1,0 +1,194 @@
+"""Detection delay at fixed alarm budget — the other axis of the Wald tradeoff.
+
+The calibration panel measures false-alarm rate vs nominal alpha on clean
+stretches; this harness measures how FAST each method raises its first alarm
+after a real onset, at a matched alarm budget. FRED injection backgrounds
+(same deterministic seeds as fred_anomaly.py), burst and shift injections
+only — spikes are instant-or-never and carry no delay information.
+
+Two threshold regimes per method and alpha in {1e-2, 1e-3}:
+  * stated:  methods that emit a p-value (mah, z1 via erfc) alarm at
+             p < alpha directly — the deployable, no-oracle regime.
+  * matched: every method (including score-only ones: mz, dspot, rrcf)
+             alarms above the empirical (1 - alpha) quantile of its own
+             scores on the calibration region [0.2n, 0.4n). This hands
+             score methods free calibration (RESEARCH.md pitfall), stated
+             plainly — it is the fair axis for ranking delay.
+
+Per series and method: first-alarm delay after onset (censored at n),
+pre-onset false alarms per 1k ticks (the realized budget). Resumable: one
+jsonl row per series.
+
+Usage:
+    python benchmarks/detection_delay.py --limit 150 --workers 2
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from frontend_run import DSpot, rrcf_scores  # noqa: E402
+from fred import _load_levels, _to_changes   # noqa: E402
+from fred_anomaly import inject, UNIVERSE, MIN_LEN  # noqa: E402
+
+ALPHAS = (1e-2, 1e-3)
+
+
+def quantile(xs, q):
+    s = sorted(xs)
+    i = min(len(s) - 1, max(0, int(q * len(s))))
+    return s[i]
+
+
+def delay_stats(scores, pvals, n, calib_lo, score_from, tau):
+    """Per method-channel: {regime_alpha: {delay, fa_per_1k}}."""
+    out = {}
+    for alpha in ALPHAS:
+        atag = f"{alpha:g}"
+        if pvals is not None:
+            alarms = [t for t in range(score_from, n) if pvals[t] is not None
+                      and pvals[t] < alpha]
+            out[f"stated_{atag}"] = _summ(alarms, tau, score_from, n)
+        thr = quantile(scores[calib_lo:score_from], 1.0 - alpha)
+        alarms = [t for t in range(score_from, n) if scores[t] > thr]
+        out[f"matched_{atag}"] = _summ(alarms, tau, score_from, n)
+    return out
+
+
+def _summ(alarms, tau, score_from, n):
+    pre = [t for t in alarms if t < tau]
+    post = [t for t in alarms if t >= tau]
+    pre_ticks = tau - score_from
+    return {"delay": (post[0] - tau) if post else None,
+            "fa_per_1k": round(1000.0 * len(pre) / max(pre_ticks, 1), 3)}
+
+
+def run_one(args):
+    sid, = args
+    levels = _load_levels(sid)
+    xs = _to_changes(levels) if levels else []
+    if len(xs) < MIN_LEN:
+        return None
+    xs, kind, (a_s, _a_e) = inject(xs, sid)
+    if kind == "spike":
+        return None                      # no delay information
+    n = len(xs)
+    calib_lo, score_from, tau = int(0.2 * n), int(0.4 * n), a_s
+    t0 = time.time()
+
+    from timemachines import laplace, mahalanobis
+
+    f = mahalanobis(laplace(3), k=3)
+    state = None
+    mah_p = [None] * n
+    z1_p = [None] * n
+    mah_s = [0.0] * n
+    z1_s = [0.0] * n
+    mz = [0.0] * n
+    zs = [0.0] * n
+    mz_m, mz_v, mz_n = 0.0, 0.0, 0
+    for t, y in enumerate(xs):
+        _, state = f(y, state)
+        z = state["base"]["z"][0]
+        zs[t] = z if z is not None else 0.0
+        if z is not None:
+            z1_s[t] = abs(z)
+            z1_p[t] = math.erfc(abs(z) / math.sqrt(2.0))
+        p = state["pvalue"]
+        if p is not None:
+            mah_p[t] = p
+            mah_s[t] = -math.log10(max(p, 1e-300))
+        mz_n += 1
+        a = max(0.02, 1.0 / mz_n)
+        if mz_n > 3 and mz_v > 0:
+            mz[t] = abs(y - mz_m) / math.sqrt(mz_v)
+        d = y - mz_m
+        mz_m += a * d
+        mz_v = (1 - a) * mz_v + a * d * (y - mz_m)
+
+    channels = {"mah": (mah_s, mah_p), "z1": (z1_s, z1_p), "mz": (mz, None)}
+    for cond, series in (("raw", xs), ("z", zs)):
+        d = DSpot(list(series[:score_from]))
+        ds = [0.0] * n
+        for t in range(score_from, n):
+            ds[t] = d.score(series[t])
+        channels[f"dspot_{cond}"] = (ds, None)
+        channels[f"rrcf_{cond}"] = (rrcf_scores(series), None)
+
+    res = {"sid": sid, "n": n, "kind": kind, "tau": tau}
+    for m, (s, p) in channels.items():
+        res[m] = delay_stats(s, p, n, calib_lo, score_from, tau)
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+KEYS = ("mah", "z1", "mz", "dspot_raw", "dspot_z", "rrcf_raw", "rrcf_z")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=150)
+    ap.add_argument("--workers", type=int, default=2)
+    ap.add_argument("--out", default=os.path.join(
+        _HERE, "detection_delay_results.jsonl"))
+    args = ap.parse_args()
+
+    ids = [u["id"] for u in json.load(open(UNIVERSE))]
+    data_dir = os.environ.get("TIMEMACHINES_FRED_DATA",
+                              os.path.join(_HERE, "data"))
+    picked = []
+    for sid in ids:
+        path = os.path.join(data_dir, f"{sid}.csv")
+        if os.path.exists(path) and os.path.getsize(path) > MIN_LEN * 12:
+            picked.append(sid)
+        if len(picked) >= args.limit:
+            break
+
+    results = []
+    if os.path.exists(args.out):
+        results = [json.loads(l) for l in open(args.out) if l.strip()]
+        done = {r["sid"] for r in results}
+        picked = [s for s in picked if s not in done]
+        print(f"resuming: {len(results)} done, {len(picked)} to go", flush=True)
+
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(
+                run_one, [(s,) for s in picked]), 1):
+            if res is None:
+                continue
+            results.append(res)
+            with open(args.out, "a") as fh:
+                fh.write(json.dumps(res) + "\n")
+            print(f"[{i}/{len(picked)}] {res['sid'][:18]:18s} {res['kind']:5s} "
+                  f"{res['seconds']:5.1f}s", flush=True)
+
+    n = len(results)
+    if not n:
+        return
+    print(f"\n=== detection delay, burst+shift injections (n={n}) ===")
+    for regime in [f"{r}_{a:g}" for r in ("stated", "matched") for a in ALPHAS]:
+        print(f"\n-- {regime} --")
+        print(f"{'method':10s} {'detect':>7s} {'med delay':>10s} {'fa/1k':>7s}")
+        for m in KEYS:
+            rows = [r[m][regime] for r in results if regime in r[m]]
+            if not rows:
+                continue
+            dl = sorted(r["delay"] for r in rows if r["delay"] is not None)
+            det = len(dl) / len(rows)
+            med = dl[len(dl) // 2] if dl else float("nan")
+            fa = sorted(r["fa_per_1k"] for r in rows)[len(rows) // 2]
+            print(f"{m:10s} {det:7.3f} {med:10.1f} {fa:7.2f}")
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/detection_delay.py
+++ b/benchmarks/detection_delay.py
@@ -110,7 +110,8 @@ def run_one(args):
         mz_n += 1
         a = max(0.02, 1.0 / mz_n)
         if mz_n > 3 and mz_v > 0:
-            mz[t] = abs(y - mz_m) / math.sqrt(mz_v)
+            # denormal-tiny variance can overflow the division to inf
+            mz[t] = min(abs(y - mz_m) / math.sqrt(mz_v), 1e12)
         d = y - mz_m
         mz_m += a * d
         mz_v = (1 - a) * mz_v + a * d * (y - mz_m)

--- a/benchmarks/fred_anomaly_v2.py
+++ b/benchmarks/fred_anomaly_v2.py
@@ -103,7 +103,8 @@ def run_one(args):
         mz_n += 1
         a = max(0.02, 1.0 / mz_n)
         if mz_n > 3 and mz_v > 0:
-            mz[t] = abs(y - mz_m) / math.sqrt(mz_v)
+            # denormal-tiny variance can overflow the division to inf
+            mz[t] = min(abs(y - mz_m) / math.sqrt(mz_v), 1e12)
         d = y - mz_m
         mz_m += a * d
         mz_v = (1 - a) * mz_v + a * d * (y - mz_m)

--- a/benchmarks/fred_anomaly_v2.py
+++ b/benchmarks/fred_anomaly_v2.py
@@ -1,0 +1,194 @@
+"""FRED injection benchmark v2 — rank-percentile scoring (see RESULTS.md §4).
+
+The v1 argmax protocol was confounded: real FRED backgrounds contain genuine
+unlabeled anomalies (2008, COVID), so argmax measured "which real crisis did
+you prefer". v2 keeps the identical deterministic injections (same seeds,
+same planted windows as fred_anomaly.py) and scores each method by the
+**rank percentile of the planted window**: the fraction of scored ticks whose
+score does not exceed the best in-window score. 1.0 means the argmax is in
+the window; 0.99 on a 5000-tick series means ~50 ticks outrank it. This is
+robust to a dominant natural event stealing the argmax.
+
+Also reported per method: the v1 argmax hit (reference), and both quantities
+with known crisis windows masked out of the ranking set (GFC 2008-06 to
+2009-12, COVID 2020-02 to 2021-06) — planted-window ticks are never masked.
+
+Resumable: one jsonl row per series; existing sids are skipped.
+
+Usage:
+    python benchmarks/fred_anomaly_v2.py --limit 150 --workers 2
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from frontend_run import DSpot, rrcf_scores  # noqa: E402
+from fred import _load_levels, _to_changes   # noqa: E402
+from fred_anomaly import inject, UNIVERSE, MIN_LEN, TYPES  # noqa: E402
+
+CRISES = (("2008-06-01", "2009-12-31"), ("2020-02-01", "2021-06-30"))
+
+
+def in_crisis(date: str) -> bool:
+    return any(lo <= date <= hi for lo, hi in CRISES)
+
+
+def rolling_mean(xs, w):
+    out, buf, s = [0.0] * len(xs), [], 0.0
+    for t, v in enumerate(xs):
+        buf.append(v)
+        s += v
+        if len(buf) > w:
+            s -= buf.pop(0)
+        out[t] = s / len(buf)
+    return out
+
+
+def rank_stats(scores, ticks, window, masked):
+    """(hit, pct) of the planted window within the candidate tick set."""
+    lo, hi = window
+    cand = [t for t in ticks if not masked[t] or lo <= t <= hi]
+    if not cand:
+        return False, 0.0
+    in_win = [scores[t] for t in cand if lo <= t <= hi]
+    if not in_win:
+        return False, 0.0
+    s_star = max(in_win)
+    argmax_t = max(cand, key=lambda t: scores[t])
+    n_above = sum(1 for t in cand if scores[t] > s_star)
+    return bool(lo <= argmax_t <= hi), 1.0 - n_above / len(cand)
+
+
+def run_one(args):
+    sid, = args
+    levels = _load_levels(sid)
+    xs = _to_changes(levels) if levels else []
+    if len(xs) < MIN_LEN:
+        return None
+    dates = [levels[i + 1][0] for i in range(len(xs))]
+    xs, kind, (a_s, a_e) = inject(xs, sid)
+    n = len(xs)
+    score_from = int(0.4 * n)
+    tol = max(50, a_e - a_s)
+    window = (a_s - tol, a_e + tol)
+    t0 = time.time()
+
+    from timemachines import laplace, mahalanobis
+
+    f = mahalanobis(laplace(3), k=3)
+    state = None
+    mah = [0.0] * n
+    z1 = [0.0] * n
+    mz = [0.0] * n
+    zs = [0.0] * n
+    mz_m, mz_v, mz_n = 0.0, 0.0, 0
+    for t, y in enumerate(xs):
+        _, state = f(y, state)
+        z = state["base"]["z"][0]
+        zs[t] = z if z is not None else 0.0
+        z1[t] = abs(zs[t])
+        p = state["pvalue"]
+        if p is not None:
+            mah[t] = -math.log10(max(p, 1e-300))
+        mz_n += 1
+        a = max(0.02, 1.0 / mz_n)
+        if mz_n > 3 and mz_v > 0:
+            mz[t] = abs(y - mz_m) / math.sqrt(mz_v)
+        d = y - mz_m
+        mz_m += a * d
+        mz_v = (1 - a) * mz_v + a * d * (y - mz_m)
+
+    scores = {"mah": mah, "mahS8": rolling_mean(mah, 8),
+              "mahS64": rolling_mean(mah, 64), "z1": z1, "mz": mz}
+    for cond, series in (("raw", xs), ("z", zs)):
+        d = DSpot(list(series[:score_from]))
+        ds = [0.0] * n
+        for t in range(score_from, n):
+            ds[t] = d.score(series[t])
+        scores[f"dspot_{cond}"] = ds
+        scores[f"rrcf_{cond}"] = rrcf_scores(series)
+
+    ticks = list(range(score_from, n))
+    masked = [in_crisis(dt) for dt in dates]
+    res = {"sid": sid, "n": n, "kind": kind, "anom": [a_s, a_e],
+           "masked_frac": round(sum(masked[score_from:]) / len(ticks), 3)}
+    for m, s in scores.items():
+        hit, pct = rank_stats(s, ticks, window, [False] * n)
+        hit_m, pct_m = rank_stats(s, ticks, window, masked)
+        res[m] = {"hit": hit, "pct": round(pct, 4),
+                  "hit_m": hit_m, "pct_m": round(pct_m, 4)}
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+KEYS = ("mah", "mahS8", "mahS64", "z1", "mz",
+        "dspot_raw", "dspot_z", "rrcf_raw", "rrcf_z")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=150)
+    ap.add_argument("--workers", type=int, default=2)
+    ap.add_argument("--out", default=os.path.join(
+        _HERE, "fred_anomaly_v2_results.jsonl"))
+    args = ap.parse_args()
+
+    ids = [u["id"] for u in json.load(open(UNIVERSE))]
+    data_dir = os.environ.get("TIMEMACHINES_FRED_DATA",
+                              os.path.join(_HERE, "data"))
+    picked = []
+    for sid in ids:
+        path = os.path.join(data_dir, f"{sid}.csv")
+        if os.path.exists(path) and os.path.getsize(path) > MIN_LEN * 12:
+            picked.append(sid)
+        if len(picked) >= args.limit:
+            break
+
+    results = []
+    if os.path.exists(args.out):
+        results = [json.loads(l) for l in open(args.out) if l.strip()]
+        done = {r["sid"] for r in results}
+        picked = [s for s in picked if s not in done]
+        print(f"resuming: {len(results)} done, {len(picked)} to go", flush=True)
+
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(
+                run_one, [(s,) for s in picked]), 1):
+            if res is None:
+                continue
+            results.append(res)
+            with open(args.out, "a") as fh:
+                fh.write(json.dumps(res) + "\n")
+            print(f"[{i}/{len(picked)}] {res['sid'][:18]:18s} {res['kind']:5s} "
+                  f"{res['seconds']:5.1f}s", flush=True)
+
+    n = len(results)
+    if not n:
+        return
+    print(f"\n=== FRED injection v2, rank-percentile (n={n}) ===")
+    print(f"{'method':10s} {'hit':>5s} {'pct':>7s} {'hit_m':>6s} {'pct_m':>7s}"
+          + "".join(f"  {t+'_pct_m':>11s}" for t in TYPES))
+    for m in KEYS:
+        line = (f"{m:10s} {sum(r[m]['hit'] for r in results)/n:5.3f} "
+                f"{sum(r[m]['pct'] for r in results)/n:7.4f} "
+                f"{sum(r[m]['hit_m'] for r in results)/n:6.3f} "
+                f"{sum(r[m]['pct_m'] for r in results)/n:7.4f}")
+        for t in TYPES:
+            sub = [r for r in results if r["kind"] == t]
+            line += f"  {sum(r[m]['pct_m'] for r in sub)/len(sub) if sub else 0:11.4f}"
+        print(line)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/mah_diagnostic.py
+++ b/benchmarks/mah_diagnostic.py
@@ -1,0 +1,189 @@
+"""Where does the mah (Mahalanobis-layer) overconfidence come from?
+
+Fact (RESULTS.md §4/§8): plain z1 on the default laplace holds ~2x nominal at
+1e-3 (≈ the genuine-anomaly base rate in FRED), but the Mahalanobis p-value
+(`mah`) runs ~9x on the same data. §4b ruled out the z-stream (sticky) as the
+cause, so the extra overshoot is inside the head. The p-value path is:
+
+    d2 (factor scatter, Woodbury)                  <- scatter estimation
+      -> Satterthwaite two-moment null c*chi2_nu   <- bulk null
+      -> GPD tail beyond the 98% quantile          <- tail machinery
+      -> Bonferroni min(p, 2*p_n), nlp channel     <- second tail + multiplicity
+
+The public knobs isolate the stages without reimplementing anything:
+
+  full    defaults (factor scatter, GPD + nlp on)
+  bulk    min_exc=1e9 -> disables BOTH the d2 GPD and the nlp GPD channel
+          (both gated by len(...) >= min_exc), leaving pure Satterthwaite chi2.
+          full vs bulk splits "the tail machinery over-rejects" from
+          "d2/null is inflated in the bulk already".
+  shrink  scatter="shrink" -> identity-shrinkage instead of the 1-factor
+          model; tests whether the factor scatter under-estimates variance and
+          inflates d2.
+  f2      factors=2 -> tests whether one factor is too few (residual
+          cross-horizon correlation left in the diagonal inflates d2).
+
+Per FRED non-price series, one pass per config, paired (same real events, so
+the difference isolates the machinery). Report median two-sided... (mah p is
+one-sided upper on d2) per-series FPR of state["pvalue"] < alpha at each
+nominal alpha, plus the empirical quantile ratio at 1e-3 so we see the size of
+the miscalibration directly.
+
+Resumable: one jsonl row per series.
+
+Usage:
+    python benchmarks/mah_diagnostic.py --limit 120 --workers 8
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from fred import _load_levels, _to_changes            # noqa: E402
+from fred_anomaly import UNIVERSE, MIN_LEN             # noqa: E402
+
+ALPHAS = (1e-2, 1e-3, 1e-4)
+_BIG = 10 ** 9
+
+
+def _make(name):
+    from timemachines import laplace, mahalanobis
+    base = lambda: laplace(3)
+    if name == "full":
+        return mahalanobis(base(), k=3)
+    if name == "bulk":
+        return mahalanobis(base(), k=3, min_exc=_BIG)   # chi2 only, no GPD/nlp
+    if name == "shrink":
+        return mahalanobis(base(), k=3, scatter="shrink")
+    if name == "f2":
+        return mahalanobis(base(), k=3, factors=2)
+    raise ValueError(name)
+
+
+CONFIGS = ("full", "bulk", "shrink", "f2")
+
+
+def one_config(xs, name):
+    f = _make(name)
+    state = None
+    n_scored = 0
+    flags = {a: 0 for a in ALPHAS}
+    z1_flags = {a: 0 for a in ALPHAS}
+    z1_n = 0
+    for y in xs:
+        _dists, state = f(y, state)
+        p = state["pvalue"]
+        if p is not None:
+            n_scored += 1
+            for a in ALPHAS:
+                if p < a:
+                    flags[a] += 1
+        # plain z1 reference from the same head's parade (one-sided-equiv two
+        # tailed erfc), only meaningful once for the 'full' config
+        if name == "full":
+            z = state["base"]["z"][0] if isinstance(state["base"], dict) else None
+            if z is not None and math.isfinite(z):
+                z1_n += 1
+                pz = math.erfc(abs(z) / math.sqrt(2.0))
+                for a in ALPHAS:
+                    if pz < a:
+                        z1_flags[a] += 1
+    out = {"fpr": {a: (flags[a] / n_scored if n_scored else None) for a in ALPHAS},
+           "n_scored": n_scored}
+    if name == "full":
+        out["z1_fpr"] = {a: (z1_flags[a] / z1_n if z1_n else None) for a in ALPHAS}
+    return out
+
+
+def run_one(job):
+    sid, = job
+    levels = _load_levels(sid)
+    xs = _to_changes(levels) if levels else []
+    if len(xs) < MIN_LEN:
+        return None
+    t0 = time.time()
+    res = {"sid": sid, "n": len(xs)}
+    for name in CONFIGS:
+        res[name] = one_config(xs, name)
+    res["z1"] = {"fpr": res["full"].pop("z1_fpr")}
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+def _median(v):
+    s = sorted(x for x in v if x is not None)
+    return s[len(s) // 2] if s else float("nan")
+
+
+def _get(fpr, a):
+    return fpr.get(str(a), fpr.get(a))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=120)
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--out", default=os.path.join(_HERE, "mah_diagnostic_results.jsonl"))
+    args = ap.parse_args()
+
+    ids = [u["id"] for u in json.load(open(UNIVERSE))]
+    data_dir = os.environ.get("TIMEMACHINES_FRED_DATA", os.path.join(_HERE, "data"))
+    picked = []
+    for sid in ids:
+        path = os.path.join(data_dir, f"{sid}.csv")
+        if os.path.exists(path) and os.path.getsize(path) > MIN_LEN * 12:
+            picked.append(sid)
+        if len(picked) >= args.limit:
+            break
+
+    results = []
+    if os.path.exists(args.out):
+        results = [json.loads(l) for l in open(args.out) if l.strip()]
+        done = {r["sid"] for r in results}
+        picked = [s for s in picked if s not in done]
+        print(f"resuming: {len(results)} done, {len(picked)} to go", flush=True)
+
+    ofh = open(args.out, "a")
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(run_one, [(s,) for s in picked]), 1):
+            if res is None:
+                continue
+            results.append(res)
+            ofh.write(json.dumps(res) + "\n")
+            ofh.flush()
+            os.fsync(ofh.fileno())
+            print(f"[{i}/{len(picked)}] {res['sid'][:18]:18s} {res['seconds']:5.1f}s",
+                  flush=True)
+    ofh.close()
+
+    n = len(results)
+    print(f"\n=== mah diagnostic (n={n}) — median per-series FPR / nominal ===")
+    print(f"{'config':10s}" + "".join(f"  fpr@{a:g}".rjust(12) for a in ALPHAS)
+          + "".join(f"  x@{a:g}".rjust(9) for a in ALPHAS))
+    order = ("z1", "bulk", "shrink", "f2", "full")
+    for name in order:
+        row = f"{name:10s}"
+        fprs = [_get(r[name]["fpr"], a) for a in ALPHAS for r in results]
+        meds = {a: _median([_get(r[name]["fpr"], a) for r in results]) for a in ALPHAS}
+        for a in ALPHAS:
+            row += f"{meds[a]:12.2e}"
+        for a in ALPHAS:
+            row += f"{meds[a] / a:9.1f}"
+        print(row)
+    print("\nReading: 'x@' = empirical/nominal ratio (1.0 = calibrated). "
+          "full vs bulk splits tail-machinery from d2/null; "
+          "shrink/f2 test the scatter model.")
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/mah_repair_sweep.py
+++ b/benchmarks/mah_repair_sweep.py
@@ -1,0 +1,180 @@
+"""Dual-axis evaluation of mah calibration fixes: FPR *and* ranking together.
+
+The mah diagnostic (mah_diagnostic.py) localizes the overconfidence to the
+bulk Satterthwaite null (d2's tail is heavier than a scaled chi2 — the
+finite-sample Hotelling effect: d2 from an EWMA-estimated inverse-covariance
+follows a heavy scaled-F, and a two-moment match keeps a too-thin tail). Two
+public-knob levers can widen the effective tail, and BOTH have a job-1/job-2
+tension, so neither may be adopted on calibration alone:
+
+  pot_level (lower)  hand the tail to the empirical GPD earlier, before the
+                     chi2 approximation diverges. Risk: the GPD region creeps
+                     toward the mode where its assumption is weaker.
+  scatter="shrink"   inflate the small "horizons disagreed" eigenvalues ->
+                     lower d2 -> better calibration, but suppresses the very
+                     directions the factor model preserves for localization.
+
+This harness plants one anomaly per FRED series (same design as
+fred_anomaly.py) and, in ONE pass per config, measures both axes on the same
+series:
+  * ranking: argmax of -log10(pvalue) over the scored region hits the planted
+    window (extended by tolerance);
+  * calibration: FPR of pvalue < alpha on the CLEAN region strictly before the
+    injection (real events remain, but the comparison is paired across configs).
+
+Configs (existing knobs only — no library change; a winner becomes a proposed
+default): base (pot0.98/factor), pot95, pot90, shrink, pot95_shrink.
+
+Resumable: one jsonl row per series.
+
+Usage:
+    python benchmarks/mah_repair_sweep.py --limit 120 --workers 8
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from fred import _load_levels, _to_changes                  # noqa: E402
+from fred_anomaly import inject, UNIVERSE, MIN_LEN, TYPES    # noqa: E402
+
+ALPHAS = (1e-2, 1e-3, 1e-4)
+CONFIGS = ("base", "pot95", "pot90", "shrink", "pot95_shrink")
+
+
+def _make(name):
+    from timemachines import laplace, mahalanobis
+    b = laplace(3)
+    if name == "base":
+        return mahalanobis(b, k=3)
+    if name == "pot95":
+        return mahalanobis(b, k=3, pot_level=0.95)
+    if name == "pot90":
+        return mahalanobis(b, k=3, pot_level=0.90)
+    if name == "shrink":
+        return mahalanobis(b, k=3, scatter="shrink")
+    if name == "pot95_shrink":
+        return mahalanobis(b, k=3, pot_level=0.95, scatter="shrink")
+    raise ValueError(name)
+
+
+def one_config(xs, name, warm, tau, score_from, window):
+    """Return (argmax_hit, {alpha: clean_FPR})."""
+    f = _make(name)
+    state = None
+    best_s, best_loc = -1.0, -1
+    n_clean = 0
+    flags = {a: 0 for a in ALPHAS}
+    for t, y in enumerate(xs):
+        _dists, state = f(y, state)
+        p = state["pvalue"]
+        if p is None:
+            continue
+        s = -math.log10(max(p, 1e-300))
+        if t >= score_from and s > best_s:       # ranking: global argmax
+            best_s, best_loc = s, t
+        if warm <= t < tau:                       # calibration: clean region
+            n_clean += 1
+            for a in ALPHAS:
+                if p < a:
+                    flags[a] += 1
+    lo, hi = window
+    return (bool(lo <= best_loc <= hi),
+            {a: (flags[a] / n_clean if n_clean else None) for a in ALPHAS})
+
+
+def run_one(job):
+    sid, = job
+    levels = _load_levels(sid)
+    xs = _to_changes(levels) if levels else []
+    if len(xs) < MIN_LEN:
+        return None
+    xs, kind, (a_s, a_e) = inject(xs, sid)
+    n = len(xs)
+    warm = int(0.2 * n)
+    score_from = int(0.4 * n)
+    tau = a_s
+    if tau - warm < 200:                          # need a clean stretch
+        return None
+    tol = max(50, a_e - a_s)
+    window = (a_s - tol, a_e + tol)
+    t0 = time.time()
+    res = {"sid": sid, "n": n, "kind": kind, "tau": tau}
+    for name in CONFIGS:
+        hit, fpr = one_config(xs, name, warm, tau, score_from, window)
+        res[name] = {"hit": hit, "fpr": fpr}
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+def _median(v):
+    s = sorted(x for x in v if x is not None)
+    return s[len(s) // 2] if s else float("nan")
+
+
+def _get(fpr, a):
+    return fpr.get(str(a), fpr.get(a))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=120)
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--out", default=os.path.join(_HERE, "mah_repair_sweep_results.jsonl"))
+    args = ap.parse_args()
+
+    ids = [u["id"] for u in json.load(open(UNIVERSE))]
+    data_dir = os.environ.get("TIMEMACHINES_FRED_DATA", os.path.join(_HERE, "data"))
+    picked = []
+    for sid in ids:
+        path = os.path.join(data_dir, f"{sid}.csv")
+        if os.path.exists(path) and os.path.getsize(path) > MIN_LEN * 12:
+            picked.append(sid)
+        if len(picked) >= args.limit:
+            break
+
+    results = []
+    if os.path.exists(args.out):
+        results = [json.loads(l) for l in open(args.out) if l.strip()]
+        done = {r["sid"] for r in results}
+        picked = [s for s in picked if s not in done]
+        print(f"resuming: {len(results)} done, {len(picked)} to go", flush=True)
+
+    ofh = open(args.out, "a")
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(run_one, [(s,) for s in picked]), 1):
+            if res is None:
+                continue
+            results.append(res)
+            ofh.write(json.dumps(res) + "\n")
+            ofh.flush()
+            os.fsync(ofh.fileno())
+            print(f"[{i}/{len(picked)}] {res['sid'][:18]:18s} {res['seconds']:5.1f}s",
+                  flush=True)
+    ofh.close()
+
+    n = len(results)
+    print(f"\n=== mah repair sweep (n={n}) — ranking vs calibration ===")
+    print(f"{'config':14s} {'argmax':>7s}" + "".join(f"  x@{a:g}".rjust(9) for a in ALPHAS))
+    for name in CONFIGS:
+        acc = sum(1 for r in results if r[name]["hit"]) / n
+        row = f"{name:14s} {acc:7.3f}"
+        for a in ALPHAS:
+            row += f"{_median([_get(r[name]['fpr'], a) for r in results]) / a:9.1f}"
+        print(row)
+    print("\nx@ = empirical/nominal clean-region FPR (1.0 = calibrated). "
+          "A fix must not drop argmax to buy calibration.")
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/mah_ucr_ranking.py
+++ b/benchmarks/mah_ucr_ranking.py
@@ -1,0 +1,128 @@
+"""UCR ranking gate for the mah scatter-model change (§4c).
+
+The FRED dual-axis sweep showed pot95_shrink calibrates best with argmax flat
+within noise — but FRED injection is the easy ranking regime. The factor
+scatter model was chosen precisely to keep sensitivity in the "horizons
+disagreed" directions that matter for localization on WAVEFORMS, which
+identity shrinkage suppresses. So the genuine ranking test for the `shrink`
+component is UCR: if shrink does not regress argmax accuracy here, it is safe
+to adopt; if it does, the repair is pot_level only (which is ranking-invariant
+by construction).
+
+Configs (identical laplace/detector settings, only the scatter/pot_level
+differ): base (factor, pot 0.98), shrink, pot95_shrink. Argmax of
+-log10(pvalue) over the scored region [train_len, n); hit within
+max(100, anomaly length). pot_level does not affect the argmax (p is monotone
+in d2), so pot95_shrink vs shrink also double-checks that invariance on UCR.
+
+Usage:
+    NUMBA_NUM_THREADS=1 python benchmarks/mah_ucr_ranking.py --limit 40 --workers 8
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from ucr_run import DATA, _NAME, parse_name, load_series  # noqa: E402
+
+WARMUP_TAIL = 4000
+CONFIGS = ("base", "shrink", "pot95_shrink")
+
+
+def _make(name):
+    from timemachines import laplace, mahalanobis
+    b = laplace(3)
+    if name == "base":
+        return mahalanobis(b, k=3)
+    if name == "shrink":
+        return mahalanobis(b, k=3, scatter="shrink")
+    if name == "pot95_shrink":
+        return mahalanobis(b, k=3, pot_level=0.95, scatter="shrink")
+    raise ValueError(name)
+
+
+def argmax_hit(ys, train_len, start, lo, hi, name):
+    f = _make(name)
+    state = None
+    best_s, best_loc = -1.0, -1
+    for t in range(start, len(ys)):
+        _dists, state = f(ys[t], state)
+        if t < train_len:
+            continue
+        p = state["pvalue"]
+        if p is None:
+            continue
+        s = -math.log10(max(p, 1e-300))
+        if s > best_s:
+            best_s, best_loc = s, t
+    return bool(lo <= best_loc <= hi)
+
+
+def run_one(job):
+    fname, = job
+    sid, name, train_len, a_start, a_end = parse_name(fname)
+    ys = load_series(os.path.join(DATA, fname))
+    start = max(0, train_len - WARMUP_TAIL)
+    tol = max(100, a_end - a_start)
+    lo, hi = a_start - tol, a_end + tol
+    t0 = time.time()
+    res = {"sid": sid, "name": name, "n": len(ys)}
+    for cfg in CONFIGS:
+        res[cfg] = argmax_hit(ys, train_len, start, lo, hi, cfg)
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=40)
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--out", default=os.path.join(_HERE, "mah_ucr_ranking_results.jsonl"))
+    args = ap.parse_args()
+    os.environ.setdefault("NUMBA_NUM_THREADS", "1")
+
+    files = sorted(f for f in os.listdir(DATA) if _NAME.match(f))
+    files.sort(key=lambda f: os.path.getsize(os.path.join(DATA, f)))
+    if args.limit:
+        files = files[:args.limit]
+
+    results = []
+    if os.path.exists(args.out):
+        results = [json.loads(l) for l in open(args.out) if l.strip()]
+        done = {r["sid"] for r in results}
+        files = [f for f in files if parse_name(f)[0] not in done]
+        print(f"resuming: {len(results)} done, {len(files)} to go", flush=True)
+
+    ofh = open(args.out, "a")
+    with Pool(args.workers) as pool:
+        for res in pool.imap_unordered(run_one, [(f,) for f in files]):
+            results.append(res)
+            ofh.write(json.dumps(res) + "\n")
+            ofh.flush()
+            os.fsync(ofh.fileno())
+            print(f"[{len(results)}] {res['sid']:03d} {res['name'][:22]:22s} "
+                  f"{res['seconds']:6.1f}s  "
+                  + " ".join(f"{c}:{int(res[c])}" for c in CONFIGS), flush=True)
+    ofh.close()
+
+    n = len(results)
+    print(f"\n=== mah UCR ranking gate (n={n}) — argmax accuracy ===")
+    for cfg in CONFIGS:
+        print(f"  {cfg:14s} {sum(r[cfg] for r in results)}/{n} = "
+              f"{sum(r[cfg] for r in results)/n:.3f}")
+    print("\nGate: shrink must not regress argmax vs base. pot95_shrink==shrink "
+          "confirms pot_level is ranking-invariant.")
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/martingale_fred.py
+++ b/benchmarks/martingale_fred.py
@@ -1,0 +1,196 @@
+"""DAMP-laplace vs DAMP-raw on genuinely martingale series — the non-circular
+test of §3b Q3.
+
+The UCR arm (martingale_transform_study.py) de-anchors series whose stationary
+template we still know, so "laplace fixes matrix profile" partly means "laplace
+undoes the transform we applied." Here there is no ground-truth template:
+FRED change series are natively martingale-ish (drift, regime shifts, fat
+tails, no clean periodicity), so laplace-z is matrix profile's ONLY viable
+normalization — per-window znorm has no stationary recurrence to lock onto.
+If DAMP-laplace beats DAMP-raw here, the repair is real in deployment, not an
+artifact of the controlled transform.
+
+Same injection design as fred_anomaly.py (deterministic spike/burst/shift per
+series). Detectors, all left matrix profile, window M=100:
+    damp_raw     znorm MP on the raw change series
+    damp_rawnn   non-normalized MP on the raw change series (control)
+    damp_lap     non-normalized MP on the laplace-z stream (laplace replaces
+                 znorm — the candidate)
+Reported per series: argmax hit (planted-window localization) and rank
+percentile of the planted window in the score ordering (robust to genuine
+crises stealing the argmax, as fred_anomaly_v2.py).
+
+Resumable: one jsonl row per series.
+
+Usage:
+    NUMBA_NUM_THREADS=1 python benchmarks/martingale_fred.py --limit 120 --workers 8
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from fred import _load_levels, _to_changes                 # noqa: E402
+from fred_anomaly import inject, UNIVERSE, MIN_LEN, TYPES   # noqa: E402
+
+M = 100
+
+
+def left_discord(xs, start, score_from, normalize):
+    """Streaming left matrix profile over xs[start:]; argmax discord location
+    among subsequences whose centre lands in [score_from, n)."""
+    import numpy as np
+    import stumpy
+    T = np.asarray(xs[start:], dtype=np.float64)
+    seed_len = max(score_from - start, M + 1)
+    if len(T) <= seed_len + 1:
+        return -1, -1.0, [0.0] * len(xs)
+    stream = stumpy.stumpi(T[:seed_len], m=M, egress=False, normalize=normalize)
+    for x in T[seed_len:]:
+        stream.update(x)
+    lp = stream.left_P_
+    full = [0.0] * len(xs)
+    best, loc = -1.0, -1
+    for i in range(len(lp)):
+        t = start + i + M // 2
+        s = lp[i]
+        if not np.isfinite(s):
+            continue
+        full[t] = float(s)
+        if t >= score_from and s > best:
+            best, loc = float(s), t
+    return loc, best, full
+
+
+def laplace_z(xs, start):
+    from timemachines import laplace
+    f = laplace(3)
+    state = None
+    zs = [0.0] * len(xs)
+    for t in range(start, len(xs)):
+        _, state = f(xs[t], state)
+        z = state["z"][0]
+        zs[t] = z if z is not None else 0.0
+    return zs
+
+
+def rank_pct(full_scores, score_from, n, window):
+    lo, hi = window
+    cand = list(range(score_from, n))
+    if not cand:
+        return 0.0
+    in_win = [full_scores[t] for t in cand if lo <= t <= hi]
+    if not in_win:
+        return 0.0
+    s_star = max(in_win)
+    above = sum(1 for t in cand if full_scores[t] > s_star)
+    return 1.0 - above / len(cand)
+
+
+def run_one(job):
+    sid, mode = job
+    levels = _load_levels(sid)
+    if not levels:
+        return None
+    if mode == "levels":
+        # keep the unit root: the genuine martingale regime (prices), where
+        # per-window znorm faces within-window drift and laplace-z is the only
+        # stationary representation. This is the analog of UCR cumsum/rw_fast.
+        xs = [v for _d, v in levels]
+    else:
+        xs = _to_changes(levels)      # stationary returns (analog of UCR raw)
+    if len(xs) < MIN_LEN:
+        return None
+    xs, kind, (a_s, a_e) = inject(xs, sid)
+    n = len(xs)
+    start = 0
+    score_from = int(0.4 * n)
+    tol = max(M, a_e - a_s)
+    window = (a_s - tol, a_e + tol)
+    t0 = time.time()
+
+    zs = laplace_z(xs, start)
+    res = {"sid": sid, "n": n, "kind": kind, "anom": [a_s, a_e]}
+    for cond, series, norm in (("damp_raw", xs, True),
+                               ("damp_rawnn", xs, False),
+                               ("damp_lap", zs, False)):
+        loc, _sc, full = left_discord(series, start, score_from, norm)
+        res[cond] = {"hit": bool(window[0] <= loc <= window[1]),
+                     "pct": round(rank_pct(full, score_from, n, window), 4)}
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+KEYS = ("damp_raw", "damp_rawnn", "damp_lap")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=120)
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--mode", choices=("levels", "changes"), default="levels",
+                    help="levels = genuine unit-root martingale test; "
+                         "changes = stationary returns (control)")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    os.environ.setdefault("NUMBA_NUM_THREADS", "1")
+    if args.out is None:
+        args.out = os.path.join(_HERE, f"martingale_fred_{args.mode}_results.jsonl")
+
+    ids = [u["id"] for u in json.load(open(UNIVERSE))]
+    data_dir = os.environ.get("TIMEMACHINES_FRED_DATA", os.path.join(_HERE, "data"))
+    picked = []
+    for sid in ids:
+        path = os.path.join(data_dir, f"{sid}.csv")
+        if os.path.exists(path) and os.path.getsize(path) > MIN_LEN * 12:
+            picked.append(sid)
+        if len(picked) >= args.limit:
+            break
+
+    results = []
+    if os.path.exists(args.out):
+        results = [json.loads(l) for l in open(args.out) if l.strip()]
+        done = {r["sid"] for r in results}
+        picked = [s for s in picked if s not in done]
+        print(f"resuming: {len(results)} done, {len(picked)} to go", flush=True)
+
+    ofh = open(args.out, "a")
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(
+                run_one, [(s, args.mode) for s in picked]), 1):
+            if res is None:
+                continue
+            results.append(res)
+            ofh.write(json.dumps(res) + "\n")
+            ofh.flush()
+            os.fsync(ofh.fileno())
+            print(f"[{i}/{len(picked)}] {res['sid'][:18]:18s} {res['kind']:5s} "
+                  f"{res['seconds']:6.1f}s", flush=True)
+    ofh.close()
+
+    nser = len(results)
+    if not nser:
+        return
+    print(f"\n=== DAMP-laplace on martingale FRED (n={nser}) ===")
+    print(f"{'detector':12s} {'hit':>6s} {'pct':>8s}" + "".join(f"  {t+'_pct':>10s}" for t in TYPES))
+    for k in KEYS:
+        line = (f"{k:12s} {sum(r[k]['hit'] for r in results)/nser:6.3f} "
+                f"{sum(r[k]['pct'] for r in results)/nser:8.4f}")
+        for t in TYPES:
+            sub = [r for r in results if r["kind"] == t]
+            line += f"  {sum(r[k]['pct'] for r in sub)/len(sub) if sub else 0:10.4f}"
+        print(line)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/martingale_transform_study.py
+++ b/benchmarks/martingale_transform_study.py
@@ -1,0 +1,255 @@
+"""Does the anchor or the recurrence drive matrix-profile's UCR dominance?
+
+Hypothesis (Cotton): UCR's biological series have an ABSOLUTE ANCHOR — a
+level-stationary baseline the waveform returns to — whereas financial series
+are martingales with no anchor (unit root). Matrix profile owns UCR because
+it exploits the anchor + recurrence; remove the anchor and the question is
+(a) does its edge collapse (anchor-artifact) or survive (genuine recurrence
+capability), (b) do wald/laplace catch up on the now-martingale series (their
+home turf), and (c) can laplace REPAIR a structural detector on de-anchored
+series.
+
+We de-anchor each UCR series with several transforms and run every detector
+on each. Anomaly LOCATION is preserved by every transform (all pointwise or
+cumulative), so the UCR argmax+tolerance protocol still scores "did you
+localize the event"; the anomaly TYPE changes under cumsum (spike->step),
+tracked in the discussion, not re-labelled.
+
+Transforms (per-step RW sd set by `window_wander` = sigma-fraction the level
+drifts over one window M; sigma from the clean prefix):
+    raw       control
+    rw_slow   y + slow random walk  (window_wander 0.15: MP's per-window
+              znorm absorbs it — de-anchors GLOBALLY, keeps local template)
+    rw_fast   y + fast random walk  (window_wander 3.0: level moves ~3 sigma
+              WITHIN a window, defeating znorm — de-anchors at window scale)
+    cumsum    integrate demeaned y  (a genuine unit root; kills the anchor
+              AND smears recurrence; spike->step)
+
+Detectors:
+    mah, mahS, z1   our head (mahalanobis(laplace) + plain parade surprise)
+    damp_raw        SOTA baseline: znorm matrix profile on raw y
+    damp_z          znorm matrix profile on laplace-z (DOUBLE normalization)
+    damp_lap        DAMP-LAPLACE: non-normalized MP on laplace-z — laplace's
+                    causal model-based normalization REPLACES znorm's crude
+                    per-window mean/std (the crossover candidate)
+    damp_rawnn      control: non-normalized MP on raw y (no normalizer at all)
+
+Usage (gentle, resumable per series):
+    NUMBA_NUM_THREADS=1 python benchmarks/martingale_transform_study.py \
+        --limit 60 --workers 8
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+import zlib
+from multiprocessing import Pool
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "src"))
+from ucr_run import DATA, _NAME, parse_name, load_series  # noqa: E402
+
+M = 100                 # subsequence window; also the hit-tolerance floor
+WARMUP_TAIL = 4000      # prefix tail fed for state warm-up (as ucr_run)
+
+
+def _rng(sid: int):
+    seed = zlib.crc32(str(sid).encode()) or 1
+
+    def gauss():
+        nonlocal seed
+        # two LCG draws -> Box-Muller; deterministic per series
+        seed = (seed * 1103515245 + 12345) & 0x7FFFFFFF
+        u = max(seed / 0x7FFFFFFF, 1e-12)
+        seed = (seed * 1103515245 + 12345) & 0x7FFFFFFF
+        v = seed / 0x7FFFFFFF
+        return math.sqrt(-2.0 * math.log(u)) * math.cos(2.0 * math.pi * v)
+    return gauss
+
+
+def transforms(ys, train_len, sid):
+    """Return {name: transformed series}. sigma from the clean prefix."""
+    n = len(ys)
+    prefix = ys[:train_len] if train_len > 10 else ys[:max(10, n // 5)]
+    mu = sum(prefix) / len(prefix)
+    sigma = math.sqrt(sum((v - mu) ** 2 for v in prefix) / len(prefix)) or 1e-8
+    gauss = _rng(sid)
+
+    def random_walk(window_wander):
+        step_sd = window_wander * sigma / math.sqrt(M)
+        out, w = [0.0] * n, 0.0
+        for t in range(n):
+            w += step_sd * gauss()
+            out[t] = ys[t] + w
+        return out
+
+    csum, acc = [0.0] * n, 0.0
+    for t in range(n):
+        acc += ys[t] - mu
+        csum[t] = acc
+
+    return {
+        "raw": list(ys),
+        "rw_slow": random_walk(0.15),
+        "rw_fast": random_walk(3.0),
+        "cumsum": csum,
+    }
+
+
+def laplace_pass(xs, start):
+    """Plain parade z (for z1 and the DAMP-laplace input) in one pass."""
+    from timemachines import laplace
+    f = laplace(3)
+    state = None
+    zs = [0.0] * len(xs)
+    z1_best = (-1.0, -1)
+    for t in range(start, len(xs)):
+        _, state = f(xs[t], state)
+        z = state["z"][0]
+        zs[t] = z if z is not None else 0.0
+    return zs
+
+
+def mahalanobis_pass(xs, start, train_len):
+    """mah (-log10 p argmax) and mahS (scan) and z1 in one causal pass."""
+    from timemachines import laplace, mahalanobis
+    from collections import deque
+    f = mahalanobis(laplace(3), k=3)
+    state = None
+    best = {"mah": (-1.0, -1), "mahS": (-1.0, -1), "z1": (-1.0, -1)}
+    WINDOWS = (8, 64)
+    wbuf = {w: deque() for w in WINDOWS}
+    wsum = {w: 0.0 for w in WINDOWS}
+    for t in range(start, len(xs)):
+        _, state = f(xs[t], state)
+        if t < train_len:
+            continue
+        z = state["base"]["z"][0] if isinstance(state["base"], dict) else None
+        if z is not None and abs(z) > best["z1"][0]:
+            best["z1"] = (abs(z), t)
+        p = state["pvalue"]
+        if p is None:
+            continue
+        s = -math.log10(max(p, 1e-300))
+        if s > best["mah"][0]:
+            best["mah"] = (s, t)
+        for w in WINDOWS:
+            wbuf[w].append(s)
+            wsum[w] += s
+            if len(wbuf[w]) > w:
+                wsum[w] -= wbuf[w].popleft()
+            if len(wbuf[w]) == w and wsum[w] / w > best["mahS"][0]:
+                best["mahS"] = (wsum[w] / w, t - w // 2)
+    return best
+
+
+def left_discord(xs, train_len, start, normalize):
+    """Streaming left matrix profile; argmax discord location in [train_len,n)."""
+    import numpy as np
+    import stumpy
+    T = np.asarray(xs[start:], dtype=np.float64)
+    seed_len = max(train_len - start, M + 1)
+    if len(T) <= seed_len + 1:
+        return -1, -1.0
+    stream = stumpy.stumpi(T[:seed_len], m=M, egress=False, normalize=normalize)
+    for x in T[seed_len:]:
+        stream.update(x)
+    lp = stream.left_P_
+    best, loc = -1.0, -1
+    for i in range(len(lp)):
+        t = start + i
+        if t < train_len:
+            continue
+        s = lp[i]
+        if np.isfinite(s) and s > best:
+            best, loc = float(s), t + M // 2
+    return loc, best
+
+
+def run_one(job):
+    fname, = job
+    sid, name, train_len, a_start, a_end = parse_name(fname)
+    ys = load_series(os.path.join(DATA, fname))
+    n = len(ys)
+    start = max(0, train_len - WARMUP_TAIL)
+    tol = max(M, a_end - a_start)
+    lo, hi = a_start - tol, a_end + tol
+    t0 = time.time()
+
+    res = {"sid": sid, "name": name, "n": n, "train_len": train_len}
+    for tname, xs in transforms(ys, train_len, sid).items():
+        cell = {}
+        mb = mahalanobis_pass(xs, start, train_len)
+        for m, (_s, locv) in mb.items():
+            cell[m] = bool(lo <= locv <= hi)
+        zs = laplace_pass(xs, start)
+        for cond, series, norm in (("damp_raw", xs, True),
+                                   ("damp_rawnn", xs, False),
+                                   ("damp_z", zs, True),
+                                   ("damp_lap", zs, False)):
+            loc, _sc = left_discord(series, train_len, start, norm)
+            cell[cond] = bool(lo <= loc <= hi)
+        res[tname] = cell
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+TRANSFORMS = ("raw", "rw_slow", "rw_fast", "cumsum")
+DETECTORS = ("mah", "mahS", "z1", "damp_raw", "damp_rawnn", "damp_z", "damp_lap")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=60,
+                    help="N shortest UCR series (0 = all 250)")
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--out", default=os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "martingale_transform_results.jsonl"))
+    args = ap.parse_args()
+    os.environ.setdefault("NUMBA_NUM_THREADS", "1")
+
+    files = sorted(f for f in os.listdir(DATA) if _NAME.match(f))
+    files.sort(key=lambda f: os.path.getsize(os.path.join(DATA, f)))
+    if args.limit:
+        files = files[:args.limit]
+
+    results = []
+    if os.path.exists(args.out):
+        results = [json.loads(l) for l in open(args.out) if l.strip()]
+        done = {r["sid"] for r in results}
+        files = [f for f in files if parse_name(f)[0] not in done]
+        print(f"resuming: {len(results)} done, {len(files)} to go", flush=True)
+    total = len(results) + len(files)
+
+    ofh = open(args.out, "a")
+    with Pool(args.workers) as pool:
+        for res in pool.imap_unordered(run_one, [(f,) for f in files]):
+            results.append(res)
+            ofh.write(json.dumps(res) + "\n")
+            ofh.flush()
+            os.fsync(ofh.fileno())
+            print(f"[{len(results)}/{total}] {res['sid']:03d} "
+                  f"{res['name'][:24]:24s} {res['seconds']:6.1f}s", flush=True)
+    ofh.close()
+
+    nseries = len(results)
+    print(f"\n=== martingale transform study (UCR n={nseries}) ===")
+    print(f"argmax accuracy; rows=detector, cols=transform\n")
+    hdr = f"{'detector':12s}" + "".join(f"{t:>10s}" for t in TRANSFORMS)
+    print(hdr)
+    for det in DETECTORS:
+        row = f"{det:12s}"
+        for t in TRANSFORMS:
+            hits = sum(1 for r in results if r.get(t, {}).get(det))
+            row += f"{hits/nseries:10.3f}"
+        print(row)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_outlier_fleet.sh
+++ b/benchmarks/run_outlier_fleet.sh
@@ -1,0 +1,40 @@
+#!/bin/zsh
+# Gentle, resumable outlier-benchmark fleet (see RESULTS.md §8).
+#
+# Every harness checkpoints per series and skips cached work, so this script
+# can be killed and re-run at any time and only pays for what is missing.
+# Stages run SEQUENTIALLY at low priority — with WORKERS=2 the whole fleet
+# never occupies more than ~2 cores. Raise WORKERS when the machine is free:
+#     WORKERS=8 ./benchmarks/run_outlier_fleet.sh
+#
+# Do not launch with nohup on this machine (SIP strips DYLD_* for protected
+# binaries); use `./benchmarks/run_outlier_fleet.sh > fleet.log 2>&1 &`.
+
+cd "$(dirname "$0")/.."
+WORKERS=${WORKERS:-2}
+PY=.venv/bin/python
+PYTSB=.venv-tsb/bin/python
+# stages are independent and resumable: log a failure, keep going
+N() { nice -n 19 "$@" || echo "!! stage failed: $*"; }
+
+echo "=== outlier fleet: workers=$WORKERS $(date) ==="
+
+# 1. TSB-AD-U tuning split, both memory configs (48 series each; tune here only)
+N $PY benchmarks/tsb_ad_run.py --split tuning --workers $WORKERS --scale-alpha 0.01 --det-alpha 0.005
+N $PY benchmarks/tsb_ad_run.py --split tuning --workers $WORKERS --scale-alpha 0.03 --det-alpha 0.02
+N $PYTSB benchmarks/tsb_ad_eval.py --split tuning --tag laplace_k3_sa0.01_da0.005
+N $PYTSB benchmarks/tsb_ad_eval.py --split tuning --tag laplace_k3_sa0.03_da0.02
+
+# 2. FRED v2 rank-percentile + detection delay (150 series each)
+N $PY benchmarks/fred_anomaly_v2.py --limit 150 --workers $WORKERS
+N $PY benchmarks/detection_delay.py --limit 150 --workers $WORKERS
+
+# 3. TSB-AD-U eval split (350 series, the long leg). Config frozen from the
+#    tuning read — EDIT the alphas below after step 1 before trusting this.
+N $PY benchmarks/tsb_ad_run.py --split eval --workers $WORKERS --scale-alpha 0.01 --det-alpha 0.005
+N $PYTSB benchmarks/tsb_ad_eval.py --split eval --tag laplace_k3_sa0.01_da0.005
+
+# 4. UCR full-250 re-run under skaters 0.13.0 (GPD tails default) — longest leg
+N $PY benchmarks/ucr_run.py --workers $WORKERS --scale-alpha 0.01 --det-alpha 0.005
+
+echo "=== fleet complete $(date) ==="

--- a/benchmarks/sticky_ablation.py
+++ b/benchmarks/sticky_ablation.py
@@ -1,0 +1,182 @@
+"""Does laplace's lattice projection (`sticky`) pollute the detection z-stream?
+
+Hypothesis (Cotton): `sticky=True` (on by default) adds near-Dirac atoms at
+revisited values. On lattice series (administrative rates whose CHANGE series
+is a run of exact zeros, quoted-on-a-grid variables) an atom is a step in the
+predictive CDF; a normal point landing near-but-not-on the atom is mapped
+through a locally near-vertical F_t and gets a spurious large |z| (2-4 sigma).
+Those pollute the SHOULDER / near-tail of the z distribution at 1e-2..1e-3 —
+which the GPD tail splice cannot repair, because the splice only replaces
+density BEYOND the frozen tail region and atoms sit in the interior. So the
+forecasting win of `sticky` (CRPS/likelihood on grid series) may be a
+detection-calibration loss.
+
+Design. Four configs = sticky {on,off} x tails {gpd,gaussian}. Per FRED
+non-price change series, one laplace pass per config, strictly causal
+(score-before-update is internal to laplace). Report, PAIRED per series (both
+configs see the same real events, so the difference isolates the sticky
+artifact):
+  * empirical two-sided false-alarm rate of erfc(|z1|) at nominal alpha
+    (z1 = state["z"][0]);
+  * mean 1-step log-likelihood (the forecasting cost of turning sticky off).
+Each series is tagged lattice vs continuous by the exact-repeat fraction of
+its change series. Falsifiable control: on CONTINUOUS series sticky must make
+~no difference; any effect must concentrate on LATTICE series.
+
+Resumable: one jsonl row per series.
+
+Usage:
+    python benchmarks/sticky_ablation.py --limit 150 --workers 8
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from multiprocessing import Pool
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)
+
+from fred import _load_levels, _to_changes            # noqa: E402
+from fred_anomaly import UNIVERSE, MIN_LEN             # noqa: E402
+
+ALPHAS = (1e-2, 1e-3, 1e-4)
+CONFIGS = (("sticky_gpd", True, "gpd"),
+           ("nosticky_gpd", False, "gpd"),
+           ("sticky_gauss", True, "gaussian"),
+           ("nosticky_gauss", False, "gaussian"))
+
+
+def repeat_frac(xs):
+    """Fraction of values that are exact repeats of an earlier value — the
+    cheap lattice proxy. High on grid/administrative series, ~0 on continuous."""
+    seen = set()
+    rep = 0
+    for v in xs:
+        if v in seen:
+            rep += 1
+        else:
+            seen.add(v)
+    return rep / len(xs)
+
+
+def one_config(xs, sticky, tails):
+    from timemachines import laplace
+    f = laplace(3, sticky=sticky, tails=tails)
+    state = None
+    n_scored = 0
+    flags = {a: 0 for a in ALPHAS}
+    ll_sum, ll_n = 0.0, 0
+    prev = None
+    for y in xs:
+        # score y under the predictive issued last tick (score-before-update)
+        if prev is not None:
+            lp = prev.logpdf(y)
+            if lp is not None and math.isfinite(lp):
+                ll_sum += max(lp, -20.0)
+                ll_n += 1
+        dists, state = f(y, state)
+        prev = dists[0]
+        z = state["z"][0]
+        if z is not None:
+            n_scored += 1
+            p = math.erfc(abs(z) / math.sqrt(2.0))   # two-sided
+            for a in ALPHAS:
+                if p < a:
+                    flags[a] += 1
+    fpr = {a: (flags[a] / n_scored if n_scored else None) for a in ALPHAS}
+    return {"fpr": fpr, "n_scored": n_scored,
+            "mean_ll": (ll_sum / ll_n if ll_n else None)}
+
+
+def run_one(job):
+    sid, = job
+    levels = _load_levels(sid)
+    xs = _to_changes(levels) if levels else []
+    if len(xs) < MIN_LEN:
+        return None
+    t0 = time.time()
+    res = {"sid": sid, "n": len(xs), "repeat_frac": round(repeat_frac(xs), 4)}
+    for name, sticky, tails in CONFIGS:
+        res[name] = one_config(xs, sticky, tails)
+    res["seconds"] = round(time.time() - t0, 1)
+    return res
+
+
+def _median(v):
+    s = sorted(x for x in v if x is not None)
+    return s[len(s) // 2] if s else float("nan")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=150)
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--lattice-thresh", type=float, default=0.05,
+                    help="repeat_frac above this = lattice series")
+    ap.add_argument("--out", default=os.path.join(_HERE, "sticky_ablation_results.jsonl"))
+    args = ap.parse_args()
+
+    ids = [u["id"] for u in json.load(open(UNIVERSE))]
+    data_dir = os.environ.get("TIMEMACHINES_FRED_DATA", os.path.join(_HERE, "data"))
+    picked = []
+    for sid in ids:
+        path = os.path.join(data_dir, f"{sid}.csv")
+        if os.path.exists(path) and os.path.getsize(path) > MIN_LEN * 12:
+            picked.append(sid)
+        if len(picked) >= args.limit:
+            break
+
+    results = []
+    if os.path.exists(args.out):
+        results = [json.loads(l) for l in open(args.out) if l.strip()]
+        done = {r["sid"] for r in results}
+        picked = [s for s in picked if s not in done]
+        print(f"resuming: {len(results)} done, {len(picked)} to go", flush=True)
+
+    ofh = open(args.out, "a")
+    with Pool(args.workers) as pool:
+        for i, res in enumerate(pool.imap_unordered(run_one, [(s,) for s in picked]), 1):
+            if res is None:
+                continue
+            results.append(res)
+            ofh.write(json.dumps(res) + "\n")
+            ofh.flush()
+            os.fsync(ofh.fileno())
+            print(f"[{i}/{len(picked)}] {res['sid'][:18]:18s} "
+                  f"rep={res['repeat_frac']:.2f} {res['seconds']:5.1f}s", flush=True)
+    ofh.close()
+
+    lat = [r for r in results if r["repeat_frac"] > args.lattice_thresh]
+    con = [r for r in results if r["repeat_frac"] <= args.lattice_thresh]
+    print(f"\n=== sticky ablation (n={len(results)}: "
+          f"{len(lat)} lattice, {len(con)} continuous) ===")
+    for label, grp in (("LATTICE (atoms fire)", lat), ("CONTINUOUS (control)", con)):
+        if not grp:
+            continue
+        print(f"\n-- {label}, n={len(grp)} --")
+        print(f"{'config':16s} {'ll':>8s}" + "".join(f"  fpr@{a:g}".rjust(12) for a in ALPHAS))
+        for name, _s, _t in CONFIGS:
+            ll = _median([r[name]["mean_ll"] for r in grp])
+            row = f"{name:16s} {ll:8.4f}"
+            for a in ALPHAS:
+                row += f"{_median([r[name]['fpr'][str(a)] if str(a) in r[name]['fpr'] else r[name]['fpr'][a] for r in grp]):12.2e}"
+            print(row)
+        # paired sticky-on minus off at 1e-3, gpd tails
+        d = [r["sticky_gpd"]["fpr"].get("0.001", r["sticky_gpd"]["fpr"].get(1e-3))
+             - r["nosticky_gpd"]["fpr"].get("0.001", r["nosticky_gpd"]["fpr"].get(1e-3))
+             for r in grp
+             if r["sticky_gpd"]["fpr"] and r["nosticky_gpd"]["fpr"]]
+        worse = sum(1 for x in d if x > 0)
+        print(f"  paired @1e-3 gpd: sticky-on FPR minus off, median {_median(d):+.2e}; "
+              f"sticky-on worse on {worse}/{len(d)}")
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tsb_ad_eval.py
+++ b/benchmarks/tsb_ad_eval.py
@@ -1,0 +1,140 @@
+"""TSB-AD-U metrics — phase 2 of the leaderboard run (see tsb_ad_run.py).
+
+Reads the per-series score arrays cached by ``tsb_ad_run.py`` and computes
+the official metric bundle (VUS-PR headline, plus VUS-ROC / AUC-PR / AUC-ROC
+and the rest of what ``get_metrics`` returns) with the official TSB-AD
+package. Run it in the dedicated metrics venv (.venv-tsb) — TSB-AD pins
+numpy<2 and torch, and must not share the detection venv:
+
+    .venv-tsb/bin/python benchmarks/tsb_ad_eval.py --split tuning
+
+Resumable: one jsonl row per (series, method); existing keys are skipped.
+Windowed scan variants (mahS<w>) are derived here from the cached ``mah``
+array — sweeping w never re-runs detection. The sliding window for VUS is
+estimated from the data with the package's own ``find_length_rank``,
+mirroring the TSB-AD benchmark scripts.
+"""
+
+from __future__ import annotations
+import argparse
+import csv
+import json
+import os
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+DATA = os.environ.get("TIMEMACHINES_TSB_DATA",
+                      os.path.join(_HERE, "data", "TSB-AD-U"))
+SCORES = os.environ.get("TIMEMACHINES_TSB_SCORES",
+                        os.path.join(_HERE, "data", "tsb_scores"))
+
+try:
+    from TSB_AD.evaluation.metrics import get_metrics
+    from TSB_AD.utils.slidingWindows import find_length_rank
+except ImportError as e:
+    raise SystemExit(
+        f"TSB-AD package not importable ({e}); run this under .venv-tsb "
+        "(uv pip install --python .venv-tsb/bin/python TSB-AD)")
+
+
+def find_csv(fname: str) -> str:
+    direct = os.path.join(DATA, fname)
+    if os.path.exists(direct):
+        return direct
+    for root, _dirs, files in os.walk(DATA):
+        if fname in files:
+            return os.path.join(root, fname)
+    raise FileNotFoundError(fname)
+
+
+def load_series(path: str):
+    with open(path) as f:
+        rows = list(csv.reader(f))
+    li = rows[0].index("Label")
+    vi = 0 if li != 0 else 1
+    ys = np.array([float(r[vi]) for r in rows[1:]], dtype=np.float64)
+    labels = np.array([int(float(r[li])) for r in rows[1:]], dtype=np.int64)
+    return ys, labels
+
+
+def rolling_mean(x: np.ndarray, w: int) -> np.ndarray:
+    """Causal rolling mean, right-aligned; prefix uses the partial window."""
+    c = np.cumsum(np.insert(x.astype(np.float64), 0, 0.0))
+    out = np.empty_like(x, dtype=np.float64)
+    n = len(x)
+    idx = np.arange(n)
+    lo = np.maximum(idx - w + 1, 0)
+    out = (c[idx + 1] - c[lo]) / (idx - lo + 1)
+    return out
+
+
+def methods_from(npz) -> dict:
+    out = {k: npz[k].astype(np.float64) for k in npz.files}
+    for w in (8, 64):
+        out[f"mahS{w}"] = rolling_mean(out["mah"], w)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--split", choices=("tuning", "eval"), default="tuning")
+    ap.add_argument("--tag", default="laplace_k3_sa0.01_da0.005")
+    args = ap.parse_args()
+
+    score_dir = os.path.join(SCORES, args.tag)
+    manifest = os.path.join(score_dir, f"manifest_{args.split}.jsonl")
+    if not os.path.exists(manifest):
+        raise SystemExit(f"no manifest {manifest} — run tsb_ad_run.py first")
+    fnames = sorted({json.loads(l)["fname"] for l in open(manifest) if l.strip()})
+
+    out_path = os.path.join(score_dir, f"metrics_{args.split}.jsonl")
+    done = set()
+    if os.path.exists(out_path):
+        done = {(r["fname"], r["method"])
+                for r in map(json.loads, open(out_path)) if r}
+    print(f"[tsb_ad_eval] {len(fnames)} series scored; "
+          f"{len(done)} (series, method) rows cached", flush=True)
+
+    with open(out_path, "a") as out:
+        for i, fname in enumerate(fnames, 1):
+            npz_path = os.path.join(score_dir, fname.replace(".csv", ".npz"))
+            if not os.path.exists(npz_path):
+                continue
+            ys, labels = load_series(find_csv(fname))
+            scores = methods_from(np.load(npz_path))
+            sw = find_length_rank(ys.reshape(-1, 1), rank=1)
+            for method, s in scores.items():
+                if (fname, method) in done:
+                    continue
+                if len(s) != len(labels):
+                    print(f"  SKIP {fname}/{method}: len {len(s)} != {len(labels)}",
+                          flush=True)
+                    continue
+                m = get_metrics(s, labels, slidingWindow=sw)
+                row = {"fname": fname, "method": method, "sliding_window": int(sw)}
+                row.update({k: (round(float(v), 6) if isinstance(v, (int, float, np.floating)) else v)
+                            for k, v in m.items()})
+                out.write(json.dumps(row) + "\n")
+            out.flush()
+            if i % 10 == 0:
+                print(f"  [{i}/{len(fnames)}] {fname}", flush=True)
+
+    # summary: mean per method, VUS-PR headline
+    rows = [json.loads(l) for l in open(out_path) if l.strip()]
+    by = {}
+    for r in rows:
+        by.setdefault(r["method"], []).append(r)
+    keys = [k for k in ("VUS-PR", "VUS-ROC", "AUC-PR", "AUC-ROC")
+            if rows and k in rows[0]]
+    print(f"\n=== TSB-AD-U {args.split} split, tag {args.tag} "
+          f"({len(fnames)} series) ===")
+    for method, rs in sorted(by.items(),
+                             key=lambda kv: -np.mean([r.get("VUS-PR", 0) for r in kv[1]])):
+        line = "  ".join(f"{k} {np.mean([r.get(k, 0.0) for r in rs]):.4f}"
+                         for k in keys)
+        print(f"{method:8s} n={len(rs):3d}  {line}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tsb_ad_eval.py
+++ b/benchmarks/tsb_ad_eval.py
@@ -69,8 +69,17 @@ def rolling_mean(x: np.ndarray, w: int) -> np.ndarray:
     return out
 
 
+def sanitize(a: np.ndarray) -> np.ndarray:
+    """AUC-family metrics only need the ordering; cap stray non-finites."""
+    if np.isfinite(a).all():
+        return a
+    finite = a[np.isfinite(a)]
+    top = (finite.max() if len(finite) else 0.0) + 1.0
+    return np.nan_to_num(a, nan=0.0, posinf=top, neginf=0.0)
+
+
 def methods_from(npz) -> dict:
-    out = {k: npz[k].astype(np.float64) for k in npz.files}
+    out = {k: sanitize(npz[k].astype(np.float64)) for k in npz.files}
     for w in (8, 64):
         out[f"mahS{w}"] = rolling_mean(out["mah"], w)
     return out

--- a/benchmarks/tsb_ad_run.py
+++ b/benchmarks/tsb_ad_run.py
@@ -1,0 +1,202 @@
+"""TSB-AD-U scorer — phase 1 of the leaderboard run (see RESEARCH.md).
+
+Computes strictly-prequential per-tick anomaly scores for every series in the
+TSB-AD-U tuning or eval split and caches them as one .npz per series. This is
+the expensive phase; it is resumable (existing .npz files are skipped) and
+deliberately cheap on the machine (default --workers 2, run it under nice).
+
+Metrics (VUS-PR etc.) are computed in phase 2 by ``tsb_ad_eval.py`` from the
+cached arrays, using the official TSB-AD package in its own venv — that
+package pins numpy<2/torch and must not share this venv. Windowed scan
+variants (mahS w) are derived at eval time from the cached ``mah`` array, so
+window sweeps never re-run detection.
+
+Protocol notes:
+  * Scores are emitted for EVERY tick (t=0 onward, score-before-update), so
+    the arrays align 1:1 with the Label column; the eval phase can restrict
+    to the post-``tr_`` region if wanted. Nothing here peeks ahead: no
+    whole-series normalisation, no threshold, one pass.
+  * Tune on the 48-series tuning split ONLY (--split tuning); the eval split
+    is run once per frozen config.
+
+Data: benchmarks/data/TSB-AD-U/ (see RESEARCH.md for the zip URL); file lists
+are fetched once from the TSB-AD GitHub repo and cached alongside the data.
+
+Usage:
+    python benchmarks/tsb_ad_run.py --split tuning --workers 2
+    python benchmarks/tsb_ad_run.py --split eval --workers 2   # long run
+"""
+
+from __future__ import annotations
+import argparse
+import csv
+import json
+import math
+import os
+import sys
+import time
+import urllib.request
+from multiprocessing import Pool
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "src"))
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+DATA = os.environ.get(
+    "TIMEMACHINES_TSB_DATA",
+    os.path.join(_HERE, "data", "TSB-AD-U"))
+SCORES = os.environ.get(
+    "TIMEMACHINES_TSB_SCORES",
+    os.path.join(_HERE, "data", "tsb_scores"))
+_LIST_URL = ("https://raw.githubusercontent.com/TheDatumOrg/TSB-AD/main/"
+             "Datasets/File_List/TSB-AD-U-{split}.csv")
+_SPLIT_FILE = {"tuning": "Tuning", "eval": "Eva"}
+
+
+def file_list(split: str) -> list:
+    """Cached official split lists (tuning: 48 series, eval: 350)."""
+    os.makedirs(DATA, exist_ok=True)
+    cache = os.path.join(DATA, f"file_list_{split}.csv")
+    if not os.path.exists(cache):
+        url = _LIST_URL.format(split=_SPLIT_FILE[split])
+        with urllib.request.urlopen(url) as r:
+            body = r.read().decode()
+        with open(cache, "w") as f:
+            f.write(body)
+    names = [ln.strip() for ln in open(cache) if ln.strip()]
+    assert names[0] == "file_name", f"unexpected list header: {names[0]}"
+    return names[1:]
+
+
+def find_csv(fname: str) -> str:
+    """The zip layout has varied (flat vs nested); search once, cheaply."""
+    direct = os.path.join(DATA, fname)
+    if os.path.exists(direct):
+        return direct
+    for root, _dirs, files in os.walk(DATA):
+        if fname in files:
+            return os.path.join(root, fname)
+    raise FileNotFoundError(f"{fname} not under {DATA} — dataset not extracted?")
+
+
+def load_series(path: str):
+    """Return (values, labels) from a TSB-AD csv (value column(s) + Label)."""
+    with open(path) as f:
+        rows = list(csv.reader(f))
+    header = rows[0]
+    li = header.index("Label")
+    vi = 0 if li != 0 else 1
+    ys = np.array([float(r[vi]) for r in rows[1:]], dtype=np.float64)
+    labels = np.array([int(float(r[li])) for r in rows[1:]], dtype=np.int8)
+    return ys, labels
+
+
+def parse_train_len(fname: str) -> int:
+    for tok in fname.replace(".csv", "").split("_"):
+        pass
+    parts = fname.replace(".csv", "").split("_")
+    return int(parts[parts.index("tr") + 1]) if "tr" in parts else 0
+
+
+def run_one(job):
+    fname, k, scale_alpha, det_alpha, out_dir = job
+    out_path = os.path.join(out_dir, fname.replace(".csv", ".npz"))
+    ys, labels = load_series(find_csv(fname))
+    n = len(ys)
+
+    from timemachines import laplace, mahalanobis
+    import skaters as _sk
+
+    f = mahalanobis(laplace(k, scale_alpha=scale_alpha), k=k, alpha=det_alpha)
+    state = None
+    mah = np.zeros(n, dtype=np.float32)   # -log10 p (Mahalanobis)
+    z1 = np.zeros(n, dtype=np.float32)    # |z_1| one-step parade surprise
+    zU = np.zeros(n, dtype=np.float32)    # union min-p channel
+    mz = np.zeros(n, dtype=np.float32)    # trivial EWMA z-score of raw y
+    mz_m, mz_v, mz_n = 0.0, 0.0, 0
+    ALPHA = 0.02
+
+    t0 = time.time()
+    for t in range(n):
+        y = float(ys[t])
+        _, state = f(y, state)
+        mz_n += 1
+        a = max(ALPHA, 1.0 / mz_n)
+        if mz_n > 3 and mz_v > 0:
+            mz[t] = abs(y - mz_m) / math.sqrt(mz_v)
+        d = y - mz_m
+        mz_m += a * d
+        mz_v = (1 - a) * mz_v + a * d * (y - mz_m)
+
+        p = state["pvalue"]
+        if p is not None:
+            mah[t] = -math.log10(max(p, 1e-300))
+        zvec = state["base"]["z"] if isinstance(state["base"], dict) else None
+        if zvec and zvec[0] is not None:
+            z1[t] = abs(zvec[0])
+        if p is not None and zvec is not None and all(v is not None for v in zvec):
+            su = mah[t]
+            for zm in zvec:
+                pm = math.erfc(abs(zm) / math.sqrt(2.0))
+                su = max(su, -math.log10(max(pm, 1e-300)))
+            zU[t] = su
+
+    np.savez_compressed(out_path, mah=mah, z1=z1, zU=zU, mz=mz)
+    return {"fname": fname, "n": n, "n_anom": int(labels.sum()),
+            "train_len": parse_train_len(fname),
+            "seconds": round(time.time() - t0, 1),
+            "skaters": getattr(_sk, "__version__", "?"),
+            "k": k, "scale_alpha": scale_alpha, "det_alpha": det_alpha}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--split", choices=("tuning", "eval"), default="tuning")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="run only the N shortest series (0 = whole split)")
+    ap.add_argument("--k", type=int, default=3)
+    ap.add_argument("--workers", type=int, default=2,
+                    help="keep low; another study may share the machine")
+    ap.add_argument("--scale-alpha", type=float, default=0.01,
+                    help="0.01 = slow memory (UCR winner); 0.03 = default")
+    ap.add_argument("--det-alpha", type=float, default=0.005)
+    args = ap.parse_args()
+
+    tag = f"laplace_k{args.k}_sa{args.scale_alpha:g}_da{args.det_alpha:g}"
+    out_dir = os.path.join(SCORES, tag)
+    os.makedirs(out_dir, exist_ok=True)
+    manifest = os.path.join(out_dir, f"manifest_{args.split}.jsonl")
+
+    names = file_list(args.split)
+    # shortest first: fast series land early, long stragglers resume cleanly
+    names.sort(key=lambda f: os.path.getsize(find_csv(f)))
+    if args.limit:
+        names = names[:args.limit]
+    done = set()
+    if os.path.exists(manifest):
+        done = {json.loads(l)["fname"] for l in open(manifest) if l.strip()}
+    todo = [f for f in names
+            if f not in done
+            or not os.path.exists(os.path.join(out_dir, f.replace(".csv", ".npz")))]
+    print(f"[tsb_ad_run] split={args.split} tag={tag}: "
+          f"{len(names)} series, {len(names) - len(todo)} cached, {len(todo)} to go",
+          flush=True)
+    if not todo:
+        return
+
+    jobs = [(f, args.k, args.scale_alpha, args.det_alpha, out_dir) for f in todo]
+    t0 = time.time()
+    with Pool(args.workers) as pool, open(manifest, "a") as mf:
+        for i, res in enumerate(pool.imap_unordered(run_one, jobs), 1):
+            mf.write(json.dumps(res) + "\n")
+            mf.flush()
+            print(f"  [{i}/{len(jobs)}] {res['fname']} n={res['n']} "
+                  f"{res['seconds']}s (elapsed {round(time.time()-t0)}s)",
+                  flush=True)
+    print(f"[tsb_ad_run] done: scores in {out_dir}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tsb_ad_run.py
+++ b/benchmarks/tsb_ad_run.py
@@ -125,7 +125,8 @@ def run_one(job):
         mz_n += 1
         a = max(ALPHA, 1.0 / mz_n)
         if mz_n > 3 and mz_v > 0:
-            mz[t] = abs(y - mz_m) / math.sqrt(mz_v)
+            # denormal-tiny variance can overflow the division to inf
+            mz[t] = min(abs(y - mz_m) / math.sqrt(mz_v), 1e12)
         d = y - mz_m
         mz_m += a * d
         mz_v = (1 - a) * mz_v + a * d * (y - mz_m)

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,9 +100,13 @@ for y in stream:
       The measured consequence for detection, full protocol in the
       <a href="https://github.com/microprediction/timemachines/tree/main/benchmarks">benchmarks</a>:</p>
 
-    <h3>The transform helps exactly the detectors it should — a gradient, not a blanket</h3>
-    <p>Same detector, same series (UCR anomaly archive, full 250 unless noted), only the
-      input changed:</p>
+    <h3>A prior state-of-the-art detector more than doubles in these coordinates</h3>
+    <p>DSPOT (Siffer et&nbsp;al., KDD 2017) — the streaming extreme-value detector that set
+      the calibrated-alarming bar — starves on raw non-stationary waveforms and feasts on
+      laplace's <em>z</em>: the front-end hands its EVT theorem exactly the stationary input
+      it always assumed, and it more than doubles. The lift is a gradient, not a blanket,
+      and that gradient is the finding. Same detector, same series (UCR anomaly archive,
+      full 250 unless noted), only the input changed:</p>
     <table>
       <thead><tr><th>detector</th><th>type</th><th>raw</th><th>transformed</th><th>verdict</th></tr></thead>
       <tbody>
@@ -145,9 +149,15 @@ for y in stream:
       structural.</strong> Full discussion with every table:
       <a href="https://github.com/microprediction/timemachines/blob/main/benchmarks/RESULTS.md">benchmarks/RESULTS.md</a> &sect;0.</p>
 
-    <p>The same transform also lifts other people's <em>forecasters</em>
-      (+2 nats/point for ETS, AutoARIMA, GARCH and Prophet, 30/30 series each) — that story
-      belongs to <a href="https://skaters.microprediction.org/">skaters</a>, where it is told.</p>
+    <p><strong>And every classical forecaster gets ~2 nats better.</strong> The same
+      transform lifts the forecasting workhorses too — +2.04 (ETS), +2.07 (AutoARIMA),
+      +1.97 (GARCH), +2.07 (Prophet) nats/point, 30/30 series each — each converging to the
+      skaters forecaster plus a few hundredths of a nat (that story
+      belongs to <a href="https://skaters.microprediction.org/">skaters</a>, where it is
+      told in full). So the one transform that makes laplace a calibrated forecaster also
+      makes prior-SOTA distributional detectors and every classical forecaster better:
+      in its coordinates each method finally sees the stationary, calibrated stream its
+      theorem assumes.</p>
 
     <h2 id="calibration">Calibration, measured</h2>
     <p>144 anomaly-free real-world prefixes (UCR training regions — clean by construction,

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,8 +48,8 @@
       each arriving point's surprise is a standard normal, and detection reduces to the textbook
       case. <code>wald</code> runs a <a href="https://skaters.microprediction.org/">skaters</a>
       forecaster underneath and emits a <strong>p-value per observation</strong> — alarm on
-      <code>p&nbsp;&lt;&nbsp;&alpha;</code> and your false-alarm rate <em>is</em> &alpha;.
-      Measured, not asserted: see <a href="#calibration">the calibration panel</a> below.
+      <code>p&nbsp;&lt;&nbsp;&alpha;</code> and your false-alarm rate <em>is</em> &alpha;
+      (see <a href="#calibration">the calibration panel</a> below).
       No threshold tuning, one pass, constant memory, strictly causal.</p>
 
     <div class="tag-row">
@@ -121,7 +121,7 @@ for y in stream:
       same operation, so the front-end improves a detector exactly to the degree it is
       distributional rather than structural.</p>
 
-    <h3>Two jobs, two regimes — the scope, stated plainly</h3>
+    <h3>Two jobs, two regimes</h3>
     <p><strong>Job 1 is localization</strong> (<em>where</em> is the anomaly: argmax, VUS —
       ranking metrics, blind to calibration by construction). <strong>Job 2 is
       alarming</strong> (<em>when</em> to fire at a stated false-alarm budget). On
@@ -129,14 +129,13 @@ for y in stream:
       behavior traces a repeating template, an anomaly is a subsequence far from every
       historical neighbour, and similarity search reads that off directly: raw DAMP scores
       0.587 on UCR where our best channel reaches 0.304, and on the TSB-AD-U leaderboard
-      our stack sits in the trivial band (&approx;0.16 VUS-PR against a 0.42 top). Those
-      numbers are quoted plainly: on job 1 over recurrent series, pattern matching wins by
-      construction.</p>
+      our stack sits in the trivial band (&approx;0.16 VUS-PR against a 0.42 top). On job 1
+      over recurrent series, pattern matching wins by construction.</p>
     <p>On <em>non-recurrent</em> series — economic data: drift, regime shifts, fat tails,
       no periodicity — there is no template, and no meaningful nearest-neighbour null:
       the only coherent notion of anomaly left is <em>surprise under a calibrated
-      predictive density</em>, which is job 2 and requires exactly this stack. Measured:
-      the calibration table below, and a detection-delay panel where at stated
+      predictive density</em>, which is job 2 and requires exactly this stack — the
+      calibration table below, and a detection-delay panel where at stated
       &alpha;=10<sup>&minus;3</sup> the surprise channel catches 63% of planted onsets at
       median delay 12 ticks while spending 1.4&times; its stated alarm budget — with no
       threshold tuning, while score-based detectors cannot state a rate at all without an

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>timemachines — streaming anomaly detection with calibrated p-values</title>
-  <meta name="description" content="Temporal online machines: streaming anomaly detection built on the calibrated surprise streams of skaters. Alarm on p < alpha and the false-alarm rate is alpha — no threshold tuning. The same transform lifts DSPOT 5x and adds +2 nats to ARIMA, ETS, GARCH and Prophet." />
+  <meta name="description" content="Temporal online machines: streaming anomaly detection built on the calibrated surprise streams of skaters. Alarm on p < alpha and the false-alarm rate is alpha — no threshold tuning. The same transform doubles DSPOT on the full UCR archive and adds +2 nats to ARIMA, ETS, GARCH and Prophet." />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="timemachines" />
   <meta property="og:title" content="timemachines — anomaly detection with calibrated p-values" />
@@ -100,15 +100,50 @@ for y in stream:
       The measured consequence for detection, full protocol in the
       <a href="https://github.com/microprediction/timemachines/tree/main/benchmarks">benchmarks</a>:</p>
 
-    <h3>Other people's detectors get better in these coordinates</h3>
-    <p>Same detector, same series (UCR anomaly archive, 60 series), only the input changed:</p>
+    <h3>The transform helps exactly the detectors it should — a gradient, not a blanket</h3>
+    <p>Same detector, same series (UCR anomaly archive, full 250 unless noted), only the
+      input changed:</p>
     <table>
-      <thead><tr><th>detector</th><th>raw series</th><th>transformed</th><th>lift</th></tr></thead>
+      <thead><tr><th>detector</th><th>type</th><th>raw</th><th>transformed</th><th>verdict</th></tr></thead>
       <tbody>
-        <tr><td>DSPOT &mdash; streaming extreme-value thresholding (Siffer et&nbsp;al., KDD 2017)</td><td>0.100</td><td><strong>0.517</strong></td><td><strong>5.2&times;</strong></td></tr>
-        <tr><td>RRCF &mdash; Robust Random Cut Forest (Guha et&nbsp;al., ICML 2016; AWS Kinesis)</td><td>0.250</td><td><strong>0.450</strong></td><td><strong>1.8&times;</strong></td></tr>
+        <tr><td>DSPOT &mdash; streaming extreme-value thresholding (Siffer et&nbsp;al., KDD 2017)</td><td>distributional</td><td>0.120</td><td><strong>0.232</strong></td><td>improved &mdash; 2&times; overall, 5.6&times; on short series, and better calibrated at depth</td></tr>
+        <tr><td>RRCF &mdash; Robust Random Cut Forest (Guha et&nbsp;al., ICML 2016; AWS Kinesis)</td><td>weak structural</td><td>0.244</td><td>0.236</td><td>wash &mdash; gains drift/scale families, loses periodic-template families</td></tr>
+        <tr><td>DAMP &mdash; left-discord matrix profile (Lu et&nbsp;al., KDD 2022; n=150)</td><td>strong structural</td><td><strong>0.587</strong></td><td>0.427</td><td><strong>hurt</strong></td></tr>
       </tbody>
     </table>
+    <p>The gradient <em>is</em> the finding. A distributional head assumes a stationary
+      stream and gets one; a similarity-search head feeds on recurring templates and the
+      transform whitens them. Manufacturing stationarity and destroying recurrence are the
+      same operation, so the front-end improves a detector exactly to the degree it is
+      distributional rather than structural.</p>
+
+    <h3>Two jobs, two regimes — the scope, stated plainly</h3>
+    <p><strong>Job 1 is localization</strong> (<em>where</em> is the anomaly: argmax, VUS —
+      ranking metrics, blind to calibration by construction). <strong>Job 2 is
+      alarming</strong> (<em>when</em> to fire at a stated false-alarm budget). On
+      <em>recurrent</em> series — periodic physiology, most waveform archives — normal
+      behavior traces a repeating template, an anomaly is a subsequence far from every
+      historical neighbour, and similarity search reads that off directly: raw DAMP scores
+      0.587 on UCR where our best channel reaches 0.304, and on the TSB-AD-U leaderboard
+      our stack sits in the trivial band (&approx;0.16 VUS-PR against a 0.42 top). Those
+      numbers are quoted plainly: on job 1 over recurrent series, pattern matching wins by
+      construction.</p>
+    <p>On <em>non-recurrent</em> series — economic data: drift, regime shifts, fat tails,
+      no periodicity — there is no template, and no meaningful nearest-neighbour null:
+      the only coherent notion of anomaly left is <em>surprise under a calibrated
+      predictive density</em>, which is job 2 and requires exactly this stack. Measured:
+      the calibration table below, and a detection-delay panel where at stated
+      &alpha;=10<sup>&minus;3</sup> the surprise channel catches 63% of planted onsets at
+      median delay 12 ticks while spending 1.4&times; its stated alarm budget — with no
+      threshold tuning, while score-based detectors cannot state a rate at all without an
+      oracle threshold. What similarity search cannot do at any accuracy — on any series —
+      is hold a stated false-alarm rate; at &alpha;=10<sup>&minus;3</sup> every method,
+      matrix profile included, drowns in false alarms on the periodic families.</p>
+    <p>One sentence: <strong>pattern matching owns &ldquo;where&rdquo; on recurrent series;
+      calibrated surprise owns &ldquo;when to alarm&rdquo; everywhere; the transform
+      improves any head exactly to the degree it is distributional rather than
+      structural.</strong> Full discussion with every table:
+      <a href="https://github.com/microprediction/timemachines/blob/main/benchmarks/RESULTS.md">benchmarks/RESULTS.md</a> &sect;0.</p>
 
     <p>The same transform also lifts other people's <em>forecasters</em>
       (+2 nats/point for ETS, AutoARIMA, GARCH and Prophet, 30/30 series each) — that story

--- a/docs/papers.html
+++ b/docs/papers.html
@@ -89,8 +89,11 @@
     <ul>
       <li>Siffer, Fouque, Termier, Largou&euml;t (KDD 2017) — <em>Anomaly detection in streams
         with extreme value theory</em> (SPOT/DSPOT). The other calibrated-threshold streaming
-        detector, and the strongest comparison on the panel; its GPD tail layer is the idea
-        <code>wald</code> gratefully adopted.</li>
+        detector, and the strongest comparison on the panel; its GPD/POT tail idea was
+        gratefully adopted twice: in the skaters forecaster itself (<code>laplace</code>
+        ships spliced GPD tails by default since skaters 0.13.0, so the surprise stream
+        arrives tail-calibrated), and again inside <code>wald</code>, whose empirical
+        null's deep tail is a streaming GPD over d&sup2; exceedances.</li>
       <li>Guha, Mishra, Roy, Schrijvers (ICML 2016) — <em>Robust random cut forest based
         anomaly detection on streams</em> (RRCF).</li>
       <li>Wu &amp; Keogh (IEEE TKDE 2023) — <em>Current time series anomaly detection

--- a/docs/papers.html
+++ b/docs/papers.html
@@ -47,8 +47,9 @@
 
     <h2>The foundation</h2>
     <ul>
-      <li>Cotton, P. — <a href="https://skaters.microprediction.org/papers.html"><em>skaters:
-        fast online distributional time-series prediction</em></a>. The body this package's
+      <li>Cotton, P. — <a href="https://skaters.microprediction.org/papers.html"><em>Transforms
+        All the Way Down: Automatic Online Distributional Forecasting by
+        Conjugation</em></a>. The skaters paper — the body this package's
         heads stand on: the forecaster, the prediction parade, and the calibrated surprise
         stream that is the API boundary between the two packages.</li>
     </ul>

--- a/src/timemachines/heads/mahalanobis.py
+++ b/src/timemachines/heads/mahalanobis.py
@@ -310,6 +310,10 @@ def mahalanobis(base, k: int, alpha: float = 0.02, scatter: str = "factor",
             data (the calibration panel measures this). Pickands--Balkema--%
             de Haan says exceedances are GPD whatever the law, so the tail
             gets its own fit — DSPOT's theorem on our multivariate statistic.
+            (Lowering it to 0.95 improves sparse-anomaly calibration but
+            regresses masking resistance under dense outliers — the
+            exceedance set is contaminated and the GPD fit corrupted; see
+            benchmarks/RESULTS.md §4c. 0.98 is kept for that reason.)
         min_exc: exceedances required before the GPD tail is trusted
             (bulk fit is used below that).
 


### PR DESCRIPTION
Continues RESULTS.md §8 (the open outlier-benchmarking items), all under skaters 0.13.0 (GPD tails default-on). Every harness checkpoints per series and resumes from cache.

- **TSB-AD-U leaderboard run**, two phases: `tsb_ad_run.py` caches strictly-prequential per-tick score arrays per series (detection venv); `tsb_ad_eval.py` computes the official VUS-PR/VUS-ROC/AUC bundle with the TSB-AD package in a separate `.venv-tsb` (it pins numpy<2). Windowed scan variants are derived at eval time from the cached `mah` array, so window sweeps never re-run detection. Tune on the 48-series tuning split only.
- **`fred_anomaly_v2.py`**: rank-percentile scoring of the planted window (with GFC/COVID masking) — fixes the v1 argmax confound where real crises stole the argmax.
- **`detection_delay.py`**: first-alarm delay after burst/shift onsets at stated (p < alpha) vs matched-empirical-quantile budgets, with realized pre-onset false-alarm rates. Known caveat noted in RESULTS.md: DSPOT's saturated score needs its native alarm channel before its delay row is quotable.
- **`run_outlier_fleet.sh`**: sequential nice'd launcher (`WORKERS` env), fault-tolerant stages.
- **RESULTS.md**: the three detached UCR runs closed out as FINAL (slow-mem full-250 mahS 0.304 > z1 0.288; default-250 z1 0.276; zbank-60 z1 0.550), §8 rewritten to harness-ready status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)